### PR TITLE
#112 Fixing 2 failing tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,6 @@
             "type": "node",
             "request": "attach",
             "port": 6004,
-            "protocol": "inspector",
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceRoot}/server/**/*.js"
@@ -53,7 +52,6 @@
                 "--extensionDevelopmentPath=${workspaceFolder}/client",
                 "--extensionTestsPath=${workspaceRoot}/dist/test/suite/index"
             ],
-            "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceRoot}/dist/**/*.js"
@@ -70,7 +68,6 @@
                 "--extensionDevelopmentPath=${workspaceRoot}/server",
                 "--extensionTestsPath=${workspaceRoot}/server/dist/test/suite/index"
             ],
-            "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceRoot}/server/out/test/**/*.js"
@@ -87,7 +84,6 @@
                 "--extensionDevelopmentPath=${workspaceFolder}/client",
                 "--extensionTestsPath=${workspaceRoot}/dist/test/integration/index"
             ],
-            "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceRoot}/dist/**/*.js"

--- a/client/test/suite/client.test.ts
+++ b/client/test/suite/client.test.ts
@@ -23,27 +23,25 @@ suite('Extension Test Suite', () => {
         const gstate = defaultDummyGlobalState()
         const newHost: string = Math.random().toString(36)
 
-        // get the client and differentiate it from the one in gstate by host
-        let mlClient1: MarklogicClient = getDbClient('', SJS, config, gstate)
-        mlClient1.params.host = newHost
+        const firstClient: MarklogicClient = getDbClient('', SJS, config, gstate)
+        firstClient.params.host = newHost
 
-        // get a second client, should not be the same or deepequal to first
-        const mlClient2: MarklogicClient = getDbClient('', SJS, config, gstate)
-        assert.notEqual(mlClient1, mlClient2)
-        assert.notDeepStrictEqual(mlClient1, mlClient2)
+        // Verify next client is different since firstClient's params were modified
+        const secondClient: MarklogicClient = getDbClient('', SJS, config, gstate)
+        assert.notStrictEqual(firstClient, secondClient)
+        assert.notDeepStrictEqual(firstClient, secondClient)
 
-        // getting mlClient1 from getDbClient should overwrite with the exact
-        // same instance as mlClient2
-        mlClient1 = getDbClient('', SJS, config, gstate)
-        assert.equal(mlClient1, mlClient2)
-        assert.notEqual(mlClient1.params.host, newHost)
+        // Verify third client is same as second client since their params are the same
+        const thirdClient = getDbClient('', SJS, config, gstate)
+        assert.strictEqual(thirdClient, secondClient)
+        assert.notStrictEqual(thirdClient.params.host, newHost)
     })
 
     test('override parser should recognize config overrides', () => {
         const queryText: string = testOverrideQueryWithGoodJSON()
         const overrides = parseQueryForOverrides(queryText, SJS)
-        assert.equal(overrides.host, 'overrideHost')
-        assert.equal(overrides.port, 12345)
+        assert.strictEqual(overrides.host, 'overrideHost')
+        assert.strictEqual(overrides.port, 12345)
     })
 
     test('overrides should not touch parameters they do not specify', () => {
@@ -55,9 +53,10 @@ suite('Extension Test Suite', () => {
         const gstate = defaultDummyGlobalState()
         const mlClient1: MarklogicClient = getDbClient(queryText, SJS, config, gstate)
 
-        assert.equal(overrides.host, mlClient1.params.host)
-        assert.equal(mlClient1.params.pwd, cfgPwd)
-        assert.equal(mlClient1.params.pathToCa, cfgPca)
+        assert.strictEqual(overrides.host, mlClient1.params.host)
+        // The pwd value in mlClient1.params will always be of type string, so have to cast the expected value
+        assert.strictEqual(mlClient1.params.pwd, String(cfgPwd))
+        assert.strictEqual(mlClient1.params.pathToCa, cfgPca)
     })
 
     test('override parser should throw if settings are invalid JSON', () => {
@@ -70,14 +69,14 @@ suite('Extension Test Suite', () => {
     test('having no override flag should cause overrides to be ignored', () => {
         const noOQuery: string = testQueryWithoutOverrides()
         const overrides: Record<string, any> = parseQueryForOverrides(noOQuery, SJS)
-        assert.equal(Object.keys(overrides).length, 0)
+        assert.strictEqual(Object.keys(overrides).length, 0)
     })
 
     test('override XQuery parser should recognize config overrides', () => {
         const queryText: string = testOverrideXQueryWithGoodJSON()
         const overrides: Record<string, any> = parseQueryForOverrides(queryText, XQY)
-        assert.equal(overrides.host, 'overrideHost')
-        assert.equal(overrides.port, 12345)
+        assert.strictEqual(overrides.host, 'overrideHost')
+        assert.strictEqual(overrides.port, 12345)
     })
 
     test('override XQuery parser should throw if settings are invalid JSON', () => {
@@ -90,7 +89,7 @@ suite('Extension Test Suite', () => {
     test('having no override XQuery flag should cause overrides to be ignored', () => {
         const noOQuery: string = testXQueryWithoutOverrides()
         const overrides: Record<string, any> = parseQueryForOverrides(noOQuery, XQY)
-        assert.equal(Object.keys(overrides).length, 0)
+        assert.strictEqual(Object.keys(overrides).length, 0)
     })
 
     test('overrides in ssl settings are honored', () => {
@@ -102,7 +101,7 @@ suite('Extension Test Suite', () => {
     })
 
     test('Sample test', () => {
-        assert.equal(-1, [1, 2, 3].indexOf(5))
-        assert.equal(-1, [1, 2, 3].indexOf(0))
+        assert.strictEqual(-1, [1, 2, 3].indexOf(5))
+        assert.strictEqual(-1, [1, 2, 3].indexOf(0))
     })
 })

--- a/client/vscQueryParameterTools.ts
+++ b/client/vscQueryParameterTools.ts
@@ -49,7 +49,7 @@ export function parseQueryForOverrides(queryText: string, language: string): Rec
  * @param language: string SJS or XQY
  * @param state most likely the extension's injected `context.globalState`
  *
- * @returns a MarkLogicVSClient based on the contents of `cfg`
+ * @returns a MarklogicClient based on the contents of `cfg`
  */
 export function getDbClient(queryText: string, language: string, cfg: WorkspaceConfiguration, state: Memento): MarklogicClient {
     const overrides: MlClientParameters = parseQueryForOverrides(queryText, language) as MlClientParameters
@@ -68,18 +68,18 @@ export function getDbClient(queryText: string, language: string, cfg: WorkspaceC
     // merge VS Code configuration and overrides
     const newParams = new MlClientParameters({ ...configParams, ...overrides })
     // if settings have changed, release and clear the client
-    const mlc = state.get(MLDBCLIENT) as MarklogicClient
-    if (mlc !== null && !mlc.hasSameParamsAs(newParams)) {
-        mlc.mldbClient.release()
+    const cachedClient = state.get(MLDBCLIENT) as MarklogicClient
+    if (cachedClient !== null && !cachedClient.hasSameParamsAs(newParams)) {
+        cachedClient.mldbClient.release()
         state.update(MLDBCLIENT, null)
-        console.debug('Cleared MarkLogicVSClient for new settings.')
+        console.debug('Removed cached instance of MarklogicClient based on change in params')
     }
     // if there's no existing client in the globalState, instantiate a new one
     if (state.get(MLDBCLIENT) === null) {
         const newClient: MarklogicClient = buildNewClient(newParams)
         try {
             state.update(MLDBCLIENT, newClient)
-            console.debug('New MarkLogicVSClient: ' + state.get(MLDBCLIENT))
+            console.debug(`Created new MarklogicClient: ${state.get(MLDBCLIENT)}`)
         }
         catch (e) {
             console.error('Error: ' + JSON.stringify(e))


### PR DESCRIPTION
Did a little cleanup while I was at it:

- Removed fields in `launch.json` that VSCode said are unused / have no effect
- Fixed warnings in client.test.ts so that e.g. `strictEqual` is used instead of `equal`
- Replaced erroneous occurrences of "MarkLogicVSClient"