### PR TITLE
Handle no paused requests better

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
     "editor.formatOnSave": true,
     "[typescript]": {
         "editor.defaultFormatter": "vscode.typescript-language-features"
-    }
+    },
+    "marklogic.port": 8055,
+    "marklogic.rejectUnauthorized": false
 }


### PR DESCRIPTION
When the user attempts to "Attach to Remote JavaScript Request" the user is presented with a list of remote requests to choose from.

However, if there are no paused requests, the list is blank, but it is not apparent that VSC is still waiting for the user to "choose" something.

This change causes a message to appear telling the user that no requests were found, and VSC does not continue "waiting".

I also fix a mistake I made in the contributing file.