### PR TITLE
DEVEXP-369: Finish eslint additions and refactor names in marklogicClient.ts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -107,6 +107,17 @@
             "multi-line"
         ],
         "func-call-spacing": "error",
-        "no-trailing-spaces": "error"
+        "no-trailing-spaces": "error",
+        "no-console": [
+            "error",
+            {
+                "allow": [
+                    "warn",
+                    "error",
+                    "debug"
+                ]
+            }
+        ],
+        "eqeqeq": "error"
     }
 }

--- a/client/JSDebugger/jsDebugConfigProvider.ts
+++ b/client/JSDebugger/jsDebugConfigProvider.ts
@@ -89,7 +89,7 @@ export class JsDebugConfigurationProvider implements vscode.DebugConfigurationPr
                 return undefined;
             });
         }
-        if (config.request == 'launch' && !config.database.match(/^\d+$/)) {
+        if (config.request === 'launch' && !config.database.match(/^\d+$/)) {
             await JsDebugManager.resolveDatabasetoId(config.username, config.password, config.database, config.hostname,
                 config.ssl, ca, config.rejectUnauthorized, config.managePort)
                 .then(resp => {
@@ -100,7 +100,7 @@ export class JsDebugConfigurationProvider implements vscode.DebugConfigurationPr
                     return null;
                 });
         }
-        if (config.request == 'launch' && !config.modules.match(/^\d+$/)) {
+        if (config.request === 'launch' && !config.modules.match(/^\d+$/)) {
             await JsDebugManager.resolveDatabasetoId(config.username, config.password, config.modules, config.hostname,
                 config.ssl, ca, config.rejectUnauthorized, config.managePort)
                 .then(resp => {

--- a/client/JSDebugger/mlDebug.ts
+++ b/client/JSDebugger/mlDebug.ts
@@ -199,7 +199,7 @@ export class MLDebugSession extends LoggingDebugSession {
                     condition: breakpoint.condition
                 });
                 newBp.add(bpString); //construct the set of new breakpoints, better ways?
-                if (path in this._bpMap && this._bpMap[path][String(breakpoint.line)] == 0) {
+                if (path in this._bpMap && this._bpMap[path][String(breakpoint.line)] === 0) {
                     const bp = new Breakpoint(true, breakpoint.line, breakpoint.column) as DebugProtocol.Breakpoint;
                     actualBreakpoints.push(bp);
                 } else {
@@ -236,11 +236,11 @@ export class MLDebugSession extends LoggingDebugSession {
                         condition: breakpoint.condition
                     } as MLbreakPoint).then(resp => {
                         const location = JSON.parse(resp)['result']['locations'][0];
-                        if (location != null) {
+                        if (location !== null) {
                             const line = this.convertDebuggerLineToClient(location['lineNumber']);
                             const actualBp = actualBreakpoints.find(bp =>
                                 line === bp.line);
-                            if (actualBp != null) actualBp.verified = true;
+                            if (actualBp !== null) actualBp.verified = true;
                             this._bpMap[path][String(line)] = 0; //verified
                         }
                     }));
@@ -534,7 +534,7 @@ export class MLDebugSession extends LoggingDebugSession {
                     const path = this._mapUrlToLocalFile(bpServer[3]);
                     const line = this.convertDebuggerLineToClient(Number(bpServer[1])); //line number
                     const bpId = this._bpMap[path][String(line)];
-                    if (bpId != 0) {
+                    if (bpId !== 0) {
                         const breakpoint: DebugProtocol.Breakpoint = new Breakpoint(true);
                         breakpoint.id = bpId;
                         this.sendEvent(new BreakpointEvent('changed', breakpoint));
@@ -606,7 +606,7 @@ export class MLDebugSession extends LoggingDebugSession {
                     condition: breakpoint.condition
                 } as MLbreakPoint).then(resp => {
                     const location = JSON.parse(resp)['result']['locations'][0];
-                    if (location != null) {
+                    if (location !== null) {
                         const line = this.convertDebuggerLineToClient(location['lineNumber']);
                         const bpId = this._bpMap[path][String(line)];
 

--- a/client/JSDebugger/mlRuntime.ts
+++ b/client/JSDebugger/mlRuntime.ts
@@ -3,7 +3,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { MarklogicClient, MlClientParameters } from '../marklogicClient';
+import { ClientContext, MlClientParameters } from '../marklogicClient';
 import { ModuleContentGetter } from '../moduleContentGetter';
 import * as request from 'request-promise';
 import * as fs from 'fs';
@@ -70,7 +70,7 @@ export class MLRuntime extends EventEmitter {
     private _endpointRoot = '/jsdbg/v1';
     private _ca: undefined | Buffer;
     private _rejectUnauthorized = true;
-    private _mlClient: MarklogicClient;
+    private _mlClient: ClientContext;
     private _mlModuleGetter: ModuleContentGetter;
 
     public getHostString(): string {
@@ -114,7 +114,7 @@ export class MLRuntime extends EventEmitter {
             this._ca = fs.readFileSync(args.pathToCa);
         }
 
-        this._mlClient = new MarklogicClient(
+        this._mlClient = new ClientContext(
             new MlClientParameters({
                 host: this._hostName,
                 port: this._dbgPort,

--- a/client/XQDebugger/xqyDebugManager.ts
+++ b/client/XQDebugger/xqyDebugManager.ts
@@ -1,5 +1,5 @@
 import { QuickPickItem, window } from 'vscode';
-import { MarklogicClient, MlClientParameters, sendXQuery, ServerQueryResponse } from '../marklogicClient';
+import { ClientContext, MlClientParameters, sendXQuery, ServerQueryResponse } from '../marklogicClient';
 import { MlxprsStatus } from '../mlxprsStatus';
 
 export interface DebugStatusQueryResponse {
@@ -26,7 +26,7 @@ export class XqyDebugManager {
       )`;
 
     public static async getAvailableRequests(params: MlClientParameters): Promise<Array<DebugStatusQueryResponse>> {
-        const client: MarklogicClient = new MarklogicClient(params);
+        const client: ClientContext = new ClientContext(params);
         const resp = await sendXQuery(client, this.listStoppedRequests)
             .result(
                 (fulfill: Record<string, any>[]) => {
@@ -39,7 +39,7 @@ export class XqyDebugManager {
         return resp;
     }
 
-    public static async connectToXqyDebugServer(mlClient: MarklogicClient): Promise<void> {
+    public static async connectToXqyDebugServer(mlClient: ClientContext): Promise<void> {
         const listServersForConnectQuery = mlClient.buildListServersForConnectQuery();
         const choices: QuickPickItem[] = await this.getAppServerListForXqy(mlClient, listServersForConnectQuery);
         if (choices.length) {
@@ -61,7 +61,7 @@ export class XqyDebugManager {
         }
     }
 
-    public static async disconnectFromXqyDebugServer(mlClient: MarklogicClient): Promise<void> {
+    public static async disconnectFromXqyDebugServer(mlClient: ClientContext): Promise<void> {
         const choices: QuickPickItem[] = await this.getAppServerListForXqy(mlClient, mlClient.listServersForDisconnectQuery);
         if (choices.length) {
             return window.showQuickPick(choices)
@@ -94,7 +94,7 @@ export class XqyDebugManager {
         this.mlxprsStatus = mlxprsStatus;
     }
 
-    public static async getAppServerListForXqy(mlClient: MarklogicClient, serverListQuery: string): Promise<QuickPickItem[]> {
+    public static async getAppServerListForXqy(mlClient: ClientContext, serverListQuery: string): Promise<QuickPickItem[]> {
         return sendXQuery(mlClient, serverListQuery)
             .result(
                 (appServers: Record<string, ServerQueryResponse>) => {

--- a/client/XQDebugger/xqyRuntime.ts
+++ b/client/XQDebugger/xqyRuntime.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { ResultProvider } from 'marklogic';
 import { InitializeRequestArguments } from './xqyDebug';
-import { sendXQuery, MarklogicClient, MlClientParameters } from '../marklogicClient';
+import { sendXQuery, ClientContext, MlClientParameters } from '../marklogicClient';
 import { parseString } from 'xml2js';
 import { ModuleContentGetter } from '../moduleContentGetter';
 
@@ -45,7 +45,7 @@ export interface XqyVariable {
 
 export class XqyRuntime extends EventEmitter {
 
-    private _mlClient: MarklogicClient;
+    private _mlClient: ClientContext;
     private _mlModuleGetter: ModuleContentGetter;
     private _clientParams: MlClientParameters;
     private _rid = '';
@@ -58,7 +58,7 @@ export class XqyRuntime extends EventEmitter {
     private _runTimeState: 'shutdown' | 'launched' | 'attached' | 'error' = 'shutdown';
 
     public getRunTimeState(): 'shutdown' | 'launched' | 'attached' | 'error' {
-	    return this._runTimeState;
+        return this._runTimeState;
     }
 
     public setRunTimeState(state: 'shutdown' | 'launched' | 'attached'): void {
@@ -74,7 +74,7 @@ export class XqyRuntime extends EventEmitter {
         return this.sendFreshQuery(query, 'dbg')
             .result(
                 (fulfill: Record<string, any>) => {
-                    console.log('fulfill (dbg): ' + JSON.stringify(fulfill));
+                    console.debug('fulfill (dbg): ' + JSON.stringify(fulfill));
                     this._rid = fulfill[0]['value'];
                     this.setRunTimeState('launched');
                     return this._rid;
@@ -88,16 +88,16 @@ export class XqyRuntime extends EventEmitter {
 
     public initialize(args: InitializeRequestArguments): void {
         this._clientParams = args.clientParams;
-        this._mlClient = new MarklogicClient(this._clientParams);
+        this._mlClient = new ClientContext(this._clientParams);
     }
 
     private sendFreshQuery(query: string, prefix: 'xdmp' | 'dbg' = 'xdmp'): ResultProvider<Record<string, any>> {
-        this._mlClient = new MarklogicClient(this._clientParams);
+        this._mlClient = new ClientContext(this._clientParams);
         return sendXQuery(this._mlClient, query, prefix);
     }
 
     public async getModuleContent(modulePath: string): Promise<string> {
-        this._mlClient = new MarklogicClient(this._clientParams);
+        this._mlClient = new ClientContext(this._clientParams);
         this._mlModuleGetter = new ModuleContentGetter(this._mlClient);
         return this._mlModuleGetter.provideTextDocumentContent(modulePath);
     }

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as ml from 'marklogic';
 import { editorJSQuery, editorSparqlQuery, editorSqlQuery, editorXQuery, editorRowsQuery } from './vscQueryDirector';
-import { MarklogicClient } from './marklogicClient';
+import { ClientContext } from './marklogicClient';
 import { cascadeOverrideClient } from './vscQueryParameterTools';
 import { ClientResponseProvider } from './clientResponseProvider';
 import { XmlFormattingEditProvider } from './xmlFormatting/Formatting';
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const sendXQuery = vscode.commands.registerTextEditorCommand('extension.sendXQuery', editor => {
         const actualQuery: string = editor.document.getText();
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient(actualQuery, XQY, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient(actualQuery, XQY, cfg, context.globalState);
         const host = client.params.host; const port = client.params.port;
         const qUri = ClientResponseProvider.encodeLocation(editor.document.uri, host, port);
         editorXQuery(client, actualQuery, qUri, editor, provider);
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const sendJSQuery = vscode.commands.registerTextEditorCommand('extension.sendJSQuery', editor => {
         const actualQuery: string = editor.document.getText();
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient(actualQuery, SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient(actualQuery, SJS, cfg, context.globalState);
         const host = client.params.host; const port = client.params.port;
         const uri = ClientResponseProvider.encodeLocation(editor.document.uri, host, port);
         editorJSQuery(client, actualQuery, uri, editor, provider);
@@ -48,7 +48,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const sendSqlQuery = vscode.commands.registerTextEditorCommand('extension.sendSqlQuery', editor => {
         const actualQuery: string = editor.document.getText();
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         const host = client.params.host; const port = client.params.port;
         const uri = ClientResponseProvider.encodeLocation(editor.document.uri, host, port);
         editorSqlQuery(client, actualQuery, uri, editor, cfg, provider);
@@ -56,7 +56,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const sendSparqlQuery = vscode.commands.registerTextEditorCommand('extension.sendSparqlQuery', editor => {
         const actualQuery: string = editor.document.getText();
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         const host = client.params.host; const port = client.params.port;
         const uri = ClientResponseProvider.encodeLocation(editor.document.uri, host, port);
         editorSparqlQuery(client, actualQuery, uri, editor, provider);
@@ -65,7 +65,7 @@ export function activate(context: vscode.ExtensionContext): void {
     function sendEditorRowsQuery(editor, rowsResponseFormat: ml.RowsResponseFormat) {
         const actualQuery: string = editor.document.getText();
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         const host = client.params.host; const port = client.params.port;
         const uri = ClientResponseProvider.encodeLocation(editor.document.uri, host, port);
         editorRowsQuery(client, actualQuery, uri, editor, provider, rowsResponseFormat);
@@ -79,27 +79,27 @@ export function activate(context: vscode.ExtensionContext): void {
 
     const connectJsServer = vscode.commands.registerCommand('extension.connectJsServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         JsDebugManager.connectToJsDebugServer(client);
     });
     const disconnectJsServer = vscode.commands.registerCommand('extension.disconnectJsServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         JsDebugManager.disconnectFromJsDebugServer(client);
     });
     const connectXqyServer = vscode.commands.registerCommand('extension.connectXqyServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         XqyDebugManager.connectToXqyDebugServer(client);
     });
     const disconnectXqyServer = vscode.commands.registerCommand('extension.disconnectXqyServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         XqyDebugManager.disconnectFromXqyDebugServer(client);
     });
     const showModule = vscode.commands.registerCommand('extension.showModule', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: MarklogicClient = cascadeOverrideClient('', XQY, cfg, context.globalState);
+        const client: ClientContext = cascadeOverrideClient('', XQY, cfg, context.globalState);
         pickAndShowModule(mprovider, client);
     });
 

--- a/client/mlxprsStatus.ts
+++ b/client/mlxprsStatus.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
-import { MarklogicClient } from './marklogicClient';
+import { ClientContext } from './marklogicClient';
 import { cascadeOverrideClient } from './vscQueryParameterTools';
 
 const SJS = 'sjs';
 
 export class MlxprsStatus {
-    private mlClient: MarklogicClient;
+    private mlClient: ClientContext;
     private statusBarItem: vscode.StatusBarItem;
     private commandId = 'mlxprs.showConnectedServers';
     private command: vscode.Disposable;

--- a/client/moduleContentGetter.ts
+++ b/client/moduleContentGetter.ts
@@ -1,16 +1,16 @@
 'use strict';
 
-import { MarklogicClient, sendXQuery, MlClientParameters } from './marklogicClient';
+import { ClientContext, sendXQuery, MlClientParameters } from './marklogicClient';
 
 export const listModulesQuery = 'cts:uris()';
 
 export class ModuleContentGetter {
-    private _mlClient: MarklogicClient;
+    private _mlClient: ClientContext;
 
-    public constructor(client: MarklogicClient) {
+    public constructor(client: ClientContext) {
         const moduleGetterParams: MlClientParameters = client.params;
         moduleGetterParams.contentDb = moduleGetterParams.modulesDb;
-        this._mlClient = new MarklogicClient(moduleGetterParams);
+        this._mlClient = new ClientContext(moduleGetterParams);
     }
 
     public host(): string {
@@ -21,12 +21,12 @@ export class ModuleContentGetter {
         return this._mlClient.params.port;
     }
 
-    public initialize(client: MarklogicClient): void {
+    public initialize(client: ClientContext): void {
         this._mlClient = client;
     }
 
     public async provideTextDocumentContent(modulePath: string): Promise<string> {
-        return this._mlClient.mldbClient.read(modulePath)
+        return this._mlClient.databaseClient.read(modulePath)
             .result(
                 (fulfill: string[]) => {
                     const moduleContent: string = fulfill[0];

--- a/client/test/integration/markLogicIntegrationTestHelper.ts
+++ b/client/test/integration/markLogicIntegrationTestHelper.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { DebugClient } from '@vscode/debugadapter-testsupport';
 
 import { JsDebugManager } from '../../JSDebugger/jsDebugManager';
-import { MarklogicClient, MlClientParameters, sendJSQuery } from '../../marklogicClient';
+import { ClientContext, MlClientParameters, sendJSQuery } from '../../marklogicClient';
 
 export class IntegrationTestHelper {
 
@@ -32,7 +32,7 @@ export class IntegrationTestHelper {
 
     public config = null;
     public debugClient = null;
-    readonly mlClient = new MarklogicClient(
+    readonly mlClient = new ClientContext(
         new MlClientParameters({
             host: this.hostname,
             port: this.port,
@@ -139,10 +139,10 @@ export class IntegrationTestHelper {
             });
     }
 
-    async getRid(client: MarklogicClient, qry: string): Promise<string[]> {
+    async getRid(client: ClientContext, qry: string): Promise<string[]> {
         const newParams: MlClientParameters = JSON.parse(JSON.stringify(client.params));
         newParams.port = this.managePort;
-        const newClient = new MarklogicClient(newParams);
+        const newClient = new ClientContext(newParams);
         return sendJSQuery(newClient, qry)
             .result(
                 (fulfill: Record<string, never>[]) => {
@@ -155,10 +155,10 @@ export class IntegrationTestHelper {
                 });
     }
 
-    async getRequestStatuses(client: MarklogicClient, qry: string): Promise<{ requestId: string }[][]> {
+    async getRequestStatuses(client: ClientContext, qry: string): Promise<{ requestId: string }[][]> {
         const newParams: MlClientParameters = JSON.parse(JSON.stringify(client.params));
         newParams.port = this.managePort;
-        const newClient = new MarklogicClient(newParams);
+        const newClient = new ClientContext(newParams);
         return sendJSQuery(newClient, qry)
             .result(
                 (fulfill) => {
@@ -171,10 +171,10 @@ export class IntegrationTestHelper {
                 });
     }
 
-    async cancelRequest(client: MarklogicClient, qry: string): Promise<unknown> {
+    async cancelRequest(client: ClientContext, qry: string): Promise<unknown> {
         const newParams: MlClientParameters = JSON.parse(JSON.stringify(client.params));
         newParams.port = this.managePort;
-        const newClient = new MarklogicClient(newParams);
+        const newClient = new ClientContext(newParams);
         return sendJSQuery(newClient, qry)
             .result(
                 () => {

--- a/client/test/suite/client.test.ts
+++ b/client/test/suite/client.test.ts
@@ -10,7 +10,7 @@ import {
 } from './testOverrideQuery';
 import { MLRuntime } from '../../JSDebugger/mlRuntime';
 import { AttachRequestArguments } from '../../JSDebugger/mlDebug';
-import { MarklogicClient } from '../../marklogicClient';
+import { ClientContext } from '../../marklogicClient';
 import { ClientResponseProvider } from '../../clientResponseProvider';
 import { getDbClient, parseQueryForOverrides } from '../../vscQueryParameterTools';
 
@@ -39,11 +39,11 @@ suite('Extension Test Suite', () => {
         const gstate = defaultDummyGlobalState();
         const newHost: string = Math.random().toString(36);
 
-        const firstClient: MarklogicClient = getDbClient('', SJS, config, gstate);
+        const firstClient: ClientContext = getDbClient('', SJS, config, gstate);
         firstClient.params.host = newHost;
 
         // Verify next client is different since firstClient's params were modified
-        const secondClient: MarklogicClient = getDbClient('', SJS, config, gstate);
+        const secondClient: ClientContext = getDbClient('', SJS, config, gstate);
         assert.notStrictEqual(firstClient, secondClient);
         assert.notDeepStrictEqual(firstClient, secondClient);
 
@@ -67,7 +67,7 @@ suite('Extension Test Suite', () => {
         const queryText: string = testOverrideQueryWithGoodJSON();
         const overrides = parseQueryForOverrides(queryText, SJS);
         const gstate = defaultDummyGlobalState();
-        const mlClient1: MarklogicClient = getDbClient(queryText, SJS, config, gstate);
+        const mlClient1: ClientContext = getDbClient(queryText, SJS, config, gstate);
 
         assert.strictEqual(overrides.host, mlClient1.params.host);
         // The pwd value in mlClient1.params will always be of type string, so have to cast the expected value

--- a/client/test/suite/defaultDb.test.ts
+++ b/client/test/suite/defaultDb.test.ts
@@ -1,9 +1,9 @@
 import * as assert from 'assert';
-import { MarklogicClient, MlClientParameters } from '../../marklogicClient';
+import { ClientContext, MlClientParameters } from '../../marklogicClient';
 
 suite('Default Documents DB Test Suite', () => {
     test('When MlClientParameters is used and the default contentDb is null', async () => {
-        const mlClient = new MarklogicClient(
+        const mlClient = new ClientContext(
             new MlClientParameters({
                 host: 'host',
                 port: 'port',
@@ -20,7 +20,7 @@ suite('Default Documents DB Test Suite', () => {
     });
 
     test('When MlClientParameters is used and the default contentDb is undefined', async () => {
-        const mlClient = new MarklogicClient(
+        const mlClient = new ClientContext(
             new MlClientParameters({
                 host: 'host',
                 port: 'port',
@@ -37,7 +37,7 @@ suite('Default Documents DB Test Suite', () => {
     });
 
     test('When MlClientParameters is used and the default contentDb is \'\'', async () => {
-        const mlClient = new MarklogicClient(
+        const mlClient = new ClientContext(
             new MlClientParameters({
                 host: 'host',
                 port: 'port',
@@ -54,7 +54,7 @@ suite('Default Documents DB Test Suite', () => {
     });
 
     test('When MlClientParameters is used and the default contentDb is missing', async () => {
-        const mlClient = new MarklogicClient(
+        const mlClient = new ClientContext(
             new MlClientParameters({
                 host: 'host',
                 port: 'port',
@@ -70,7 +70,7 @@ suite('Default Documents DB Test Suite', () => {
     });
 
     test('When MlClientParameters is used and the default contentDb contains a value', async () => {
-        const mlClient = new MarklogicClient(
+        const mlClient = new ClientContext(
             new MlClientParameters({
                 host: 'host',
                 port: 'port',

--- a/client/test/suite/dummyGlobalState.ts
+++ b/client/test/suite/dummyGlobalState.ts
@@ -1,27 +1,27 @@
 'use strict';
 
 import { Memento } from 'vscode';
-import { MarklogicClient, MlClientParameters } from '../../marklogicClient';
+import { ClientContext, MlClientParameters } from '../../marklogicClient';
 
 /**
  *
  */
 export class DummyGlobalState implements Memento {
-    dummyClient: MarklogicClient;
+    dummyClient: ClientContext;
     get<T>(key: string): T
     get<T>(key: string, defaultValue: T): T
 
-    get(key: any, defaultValue?: any): MarklogicClient {
+    get(key: any, defaultValue?: any): ClientContext {
         return this.dummyClient;
     }
     update(key: string, value: any): Thenable<void> {
         return new Promise(() => {
-            this.dummyClient = value as MarklogicClient;
+            this.dummyClient = value as ClientContext;
         });
     }
 
     constructor(params: MlClientParameters) {
-        this.dummyClient = new MarklogicClient(params);
+        this.dummyClient = new ClientContext(params);
     }
     keys(): readonly string[] {
         throw new Error('Method not implemented.');

--- a/client/test/suite/rowsQuery.test.ts
+++ b/client/test/suite/rowsQuery.test.ts
@@ -19,7 +19,7 @@ function dummyRowsQuerier(): ml.Rows {
     };
 }
 const gstate = defaultDummyGlobalState();
-gstate.dummyClient.mldbClient.rows = dummyRowsQuerier();
+gstate.dummyClient.databaseClient.rows = dummyRowsQuerier();
 
 suite('Rows Query Test Suite', () => {
 

--- a/client/vscModuleContentProvider.ts
+++ b/client/vscModuleContentProvider.ts
@@ -1,8 +1,10 @@
 'use strict';
 
-import { Event, EventEmitter, TextDocument, TextDocumentContentProvider, Uri,
-    window, workspace } from 'vscode';
-import { MarklogicClient } from './marklogicClient';
+import {
+    Event, EventEmitter, TextDocument, TextDocumentContentProvider, Uri,
+    window, workspace
+} from 'vscode';
+import { ClientContext } from './marklogicClient';
 import { ModuleContentGetter } from './moduleContentGetter';
 
 const scheme = 'mlmodule';
@@ -18,7 +20,7 @@ export class ModuleContentProvider implements TextDocumentContentProvider {
     private _onDidChange = new EventEmitter<Uri>();
     private _mlModuleGetter: ModuleContentGetter;
 
-    public initialize(client: MarklogicClient): void {
+    public initialize(client: ClientContext): void {
         this._mlModuleGetter = new ModuleContentGetter(client);
     }
 
@@ -35,7 +37,7 @@ export class ModuleContentProvider implements TextDocumentContentProvider {
     }
 }
 
-export async function pickAndShowModule(mprovider: ModuleContentProvider, client: MarklogicClient): Promise<void> {
+export async function pickAndShowModule(mprovider: ModuleContentProvider, client: ClientContext): Promise<void> {
     mprovider.initialize(client);
     mprovider.listModules()
         .then((moduleUris: string[]) => {

--- a/client/vscQueryDirector.ts
+++ b/client/vscQueryDirector.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { MarklogicClient, sendJSQuery, sendSparql, sendXQuery, sendRows } from './marklogicClient';
+import { ClientContext, sendJSQuery, sendSparql, sendXQuery, sendRows } from './marklogicClient';
 import { TextDocument, TextEdit, TextEditor, Uri, WorkspaceEdit, commands, window, workspace, WorkspaceConfiguration } from 'vscode';
 import { ClientResponseProvider } from './clientResponseProvider';
 import { contentType, RowsResponse } from 'marklogic';
@@ -51,7 +51,7 @@ async function showFormattedResults(uri: Uri, editor: TextEditor): Promise<TextE
 
 
 export function editorJSQuery(
-    db: MarklogicClient,
+    db: ClientContext,
     actualQuery: string,
     uri: Uri,
     editor: TextEditor,
@@ -69,7 +69,7 @@ export function editorJSQuery(
 
 
 export function editorXQuery(
-    db: MarklogicClient,
+    db: ClientContext,
     actualQuery: string,
     uri: Uri,
     editor: TextEditor,
@@ -94,7 +94,7 @@ export function buildSqlOptions(cfg: WorkspaceConfiguration): Array<string> {
 }
 
 export function editorSqlQuery(
-    db: MarklogicClient,
+    db: ClientContext,
     sqlQuery: string,
     uri: Uri,
     editor: TextEditor,
@@ -115,7 +115,7 @@ export function editorSqlQuery(
 
 
 export function editorSparqlQuery(
-    db: MarklogicClient,
+    db: ClientContext,
     sparqlQuery: string,
     uri: Uri,
     editor: TextEditor,
@@ -133,7 +133,7 @@ export function editorSparqlQuery(
 }
 
 
-export function editorRowsQuery(db: MarklogicClient, actualQuery: string, uri: Uri,
+export function editorRowsQuery(db: ClientContext, actualQuery: string, uri: Uri,
     editor: TextEditor, provider: ClientResponseProvider, resultFormat: ml.RowsResponseFormat): void {
     sendRows(db, actualQuery, resultFormat)
         .then(

--- a/client/xmlFormatting/XmlFormatter.ts
+++ b/client/xmlFormatting/XmlFormatter.ts
@@ -1,3 +1,5 @@
+/* eslint-disable eqeqeq */
+// Need to do some research to determine if it is safe to convert these "==" to "==="
 'use strict';
 
 // Based on pretty-data (https://github.com/vkiryukhin/pretty-data)

--- a/server/test/runTest.ts
+++ b/server/test/runTest.ts
@@ -6,7 +6,7 @@ async function main(): Promise<void> {
     try {
         // The folder containing the Extension Manifest package.json
         // Passed to `--extensionDevelopmentPath`
-        console.log('Starting to run tests');
+        console.debug('Starting to run tests');
         const extensionDevelopmentPath = path.resolve(__dirname, '../../../../');
 
         // The path to the extension test script

--- a/server/test/suite/server.test.ts
+++ b/server/test/suite/server.test.ts
@@ -10,11 +10,11 @@ import * as completionsSjs from '../../completionsSjs';
 suite('Extension Tests', () => {
 
     before(() => {
-        console.log('starting tests!');
+        console.debug('starting server tests!');
     });
 
     after(() => {
-        console.log('All tests done!');
+        console.debug('All server tests done!');
     });
 
     // Defines a Mocha unit test


### PR DESCRIPTION
1) Make the last couple of desired additions to eslint.json to help ensure a clean project.
2) Ensure linting passes without any errors.
3) Rename the "MarkLogicClient" class to "ClientContext" to avoid confusion
4) Rename the "mldbClient" property in that class to "databaseClient" to avoid confusion.