### PR TITLE
DEVEXP-370: Standardize the naming of variables of the type ClientContext

### DIFF
--- a/client/JSDebugger/jsDebugManager.ts
+++ b/client/JSDebugger/jsDebugManager.ts
@@ -30,21 +30,21 @@ export class JsDebugManager {
         return request.get(url, options);
     }
 
-    public static async getFilteredListOfJsAppServers(mlClient: ClientContext, requiredResponse: string): Promise<QuickPickItem[]> {
-        const listServersForConnectQuery = mlClient.buildListServersForConnectQuery();
-        const choices: QuickPickItem[] = await this.getAppServerListForJs(mlClient, listServersForConnectQuery) as QuickPickItem[];
+    public static async getFilteredListOfJsAppServers(dbClientContext: ClientContext, requiredResponse: string): Promise<QuickPickItem[]> {
+        const listServersForConnectQuery = dbClientContext.buildListServersForConnectQuery();
+        const choices: QuickPickItem[] = await this.getAppServerListForJs(dbClientContext, listServersForConnectQuery) as QuickPickItem[];
         return await this.filterServers(choices, requiredResponse);
     }
 
-    public static async connectToJsDebugServer(mlClient: ClientContext): Promise<void> {
-        const filteredServerItems: QuickPickItem[] = await this.getFilteredListOfJsAppServers(mlClient, 'false');
+    public static async connectToJsDebugServer(dbClientContext: ClientContext): Promise<void> {
+        const filteredServerItems: QuickPickItem[] = await this.getFilteredListOfJsAppServers(dbClientContext, 'false');
         if (filteredServerItems.length) {
             return window.showQuickPick(filteredServerItems)
                 .then((serverChoice: QuickPickItem) => {
                     return this.connectToNamedJsDebugServer(serverChoice.label)
                         .then(
                             () => {
-                                window.showInformationMessage(`Successfully connected ${serverChoice.label} on ${mlClient.params.host}`);
+                                window.showInformationMessage(`Successfully connected ${serverChoice.label} on ${dbClientContext.params.host}`);
                                 this.requestStatusBarItemUpdate();
                             },
                             (err) => {
@@ -100,15 +100,15 @@ export class JsDebugManager {
         return filteredChoices;
     }
 
-    public static async disconnectFromJsDebugServer(mlClient: ClientContext) {
-        const filteredServerItems: QuickPickItem[] = await this.getFilteredListOfJsAppServers(mlClient, 'true');
+    public static async disconnectFromJsDebugServer(dbClientContext: ClientContext) {
+        const filteredServerItems: QuickPickItem[] = await this.getFilteredListOfJsAppServers(dbClientContext, 'true');
         if (filteredServerItems.length) {
             return window.showQuickPick(filteredServerItems)
                 .then((serverChoice: QuickPickItem) => {
                     return this.disconnectFromNamedJsDebugServer(serverChoice.label)
                         .then(
                             () => {
-                                window.showInformationMessage(`Successfully disconnected ${serverChoice.label} on ${mlClient.params.host}`);
+                                window.showInformationMessage(`Successfully disconnected ${serverChoice.label} on ${dbClientContext.params.host}`);
                                 this.requestStatusBarItemUpdate();
                             },
                             (err) => {
@@ -117,7 +117,7 @@ export class JsDebugManager {
                             });
                 });
         } else {
-            window.showWarningMessage(`No stopped servers found on ${mlClient.params.host}`);
+            window.showWarningMessage(`No stopped servers found on ${dbClientContext.params.host}`);
             this.requestStatusBarItemUpdate();
             return null;
         }
@@ -277,11 +277,11 @@ export class JsDebugManager {
         this.mlxprsStatus = mlxprsStatus;
     }
 
-    public static async getAppServerListForJs(mlClient: ClientContext, serverListQuery: string): Promise<QuickPickItem[]> {
-        return sendXQuery(mlClient, serverListQuery)
+    public static async getAppServerListForJs(dbClientContext: ClientContext, serverListQuery: string): Promise<QuickPickItem[]> {
+        return sendXQuery(dbClientContext, serverListQuery)
             .result(
                 (appServers: Record<string, ServerQueryResponse>) => {
-                    return mlClient.buildAppServerChoicesFromServerList(appServers);
+                    return dbClientContext.buildAppServerChoicesFromServerList(appServers);
                 },
                 err => {
                     window.showErrorMessage(`couldn't get a list of servers: ${JSON.stringify(err)}`);

--- a/client/JSDebugger/mlRuntime.ts
+++ b/client/JSDebugger/mlRuntime.ts
@@ -70,11 +70,11 @@ export class MLRuntime extends EventEmitter {
     private _endpointRoot = '/jsdbg/v1';
     private _ca: undefined | Buffer;
     private _rejectUnauthorized = true;
-    private _mlClient: ClientContext;
+    private dbClientContext: ClientContext;
     private _mlModuleGetter: ModuleContentGetter;
 
     public getHostString(): string {
-        return `${this._mlClient.params.host}:${this._mlClient.params.port}`;
+        return `${this.dbClientContext.params.host}:${this.dbClientContext.params.port}`;
     }
 
     //Internal
@@ -114,7 +114,7 @@ export class MLRuntime extends EventEmitter {
             this._ca = fs.readFileSync(args.pathToCa);
         }
 
-        this._mlClient = new ClientContext(
+        this.dbClientContext = new ClientContext(
             new MlClientParameters({
                 host: this._hostName,
                 port: this._dbgPort,
@@ -128,7 +128,7 @@ export class MLRuntime extends EventEmitter {
                 rejectUnauthorized: args.rejectUnauthorized
             })
         );
-        this._mlModuleGetter = new ModuleContentGetter(this._mlClient);
+        this._mlModuleGetter = new ModuleContentGetter(this.dbClientContext);
     }
 
     public setRid(rid: string): void {

--- a/client/XQDebugger/xqyRuntime.ts
+++ b/client/XQDebugger/xqyRuntime.ts
@@ -45,7 +45,7 @@ export interface XqyVariable {
 
 export class XqyRuntime extends EventEmitter {
 
-    private _mlClient: ClientContext;
+    private dbClientContext: ClientContext;
     private _mlModuleGetter: ModuleContentGetter;
     private _clientParams: MlClientParameters;
     private _rid = '';
@@ -88,17 +88,17 @@ export class XqyRuntime extends EventEmitter {
 
     public initialize(args: InitializeRequestArguments): void {
         this._clientParams = args.clientParams;
-        this._mlClient = new ClientContext(this._clientParams);
+        this.dbClientContext = new ClientContext(this._clientParams);
     }
 
     private sendFreshQuery(query: string, prefix: 'xdmp' | 'dbg' = 'xdmp'): ResultProvider<Record<string, any>> {
-        this._mlClient = new ClientContext(this._clientParams);
-        return sendXQuery(this._mlClient, query, prefix);
+        this.dbClientContext = new ClientContext(this._clientParams);
+        return sendXQuery(this.dbClientContext, query, prefix);
     }
 
     public async getModuleContent(modulePath: string): Promise<string> {
-        this._mlClient = new ClientContext(this._clientParams);
-        this._mlModuleGetter = new ModuleContentGetter(this._mlClient);
+        this.dbClientContext = new ClientContext(this._clientParams);
+        this._mlModuleGetter = new ModuleContentGetter(this.dbClientContext);
         return this._mlModuleGetter.provideTextDocumentContent(modulePath);
     }
 
@@ -228,11 +228,11 @@ export class XqyRuntime extends EventEmitter {
     }
 
     public disable(): ResultProvider<Record<string, any>> {
-        return sendXQuery(this._mlClient, `dbg:value(${this._rid})`);
+        return sendXQuery(this.dbClientContext, `dbg:value(${this._rid})`);
     }
 
     public terminate(): ResultProvider<Record<string, any>> {
-        return sendXQuery(this._mlClient, 'dbg:disconnent(xdmp:server())');
+        return sendXQuery(this.dbClientContext, 'dbg:disconnent(xdmp:server())');
     }
 
     public static parseExprXML(exprXMLString: string): Array<XqyExpr> {

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -60,30 +60,30 @@ export function activate(context: vscode.ExtensionContext): void {
 
     const connectJsServer = vscode.commands.registerCommand('extension.connectJsServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
-        JsDebugManager.connectToJsDebugServer(client);
+        const dbClientContext: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        JsDebugManager.connectToJsDebugServer(dbClientContext);
     });
     const disconnectJsServer = vscode.commands.registerCommand('extension.disconnectJsServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
-        JsDebugManager.disconnectFromJsDebugServer(client);
+        const dbClientContext: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        JsDebugManager.disconnectFromJsDebugServer(dbClientContext);
     });
     const connectXqyServer = vscode.commands.registerCommand('extension.connectXqyServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
-        XqyDebugManager.connectToXqyDebugServer(client);
+        const dbClientContext: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        XqyDebugManager.connectToXqyDebugServer(dbClientContext);
     });
     const disconnectXqyServer = vscode.commands.registerCommand('extension.disconnectXqyServer', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
-        XqyDebugManager.disconnectFromXqyDebugServer(client);
+        const dbClientContext: ClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        XqyDebugManager.disconnectFromXqyDebugServer(dbClientContext);
     });
 
 
     const showModule = vscode.commands.registerCommand('extension.showModule', () => {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-        const client: ClientContext = cascadeOverrideClient('', XQY, cfg, context.globalState);
-        pickAndShowModule(mprovider, client);
+        const dbClientContext: ClientContext = cascadeOverrideClient('', XQY, cfg, context.globalState);
+        pickAndShowModule(mprovider, dbClientContext);
     });
 
     handleUnload(context, [

--- a/client/mlxprsStatus.ts
+++ b/client/mlxprsStatus.ts
@@ -5,7 +5,7 @@ import { cascadeOverrideClient } from './vscQueryParameterTools';
 const SJS = 'sjs';
 
 export class MlxprsStatus {
-    private mlClient: ClientContext;
+    private dbClientContext: ClientContext;
     private statusBarItem: vscode.StatusBarItem;
     private commandId = 'mlxprs.showConnectedServers';
     private command: vscode.Disposable;
@@ -15,7 +15,7 @@ export class MlxprsStatus {
     constructor(context: vscode.ExtensionContext) {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
         this.managePort = Number(cfg.get('marklogic.managePort'));
-        this.mlClient = cascadeOverrideClient('', SJS, cfg, context.globalState);
+        this.dbClientContext = cascadeOverrideClient('', SJS, cfg, context.globalState);
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
         this.command = vscode.commands.registerCommand(this.commandId, () => {
             this.handleStatusBarCommand();
@@ -32,7 +32,7 @@ export class MlxprsStatus {
     }
 
     requestUpdate(): void {
-        this.mlClient.getConnectedServers(this, this.managePort, this.updateStatusBarItem);
+        this.dbClientContext.getConnectedServers(this, this.managePort, this.updateStatusBarItem);
     }
 
     updateStatusBarItem(connectedServers: string[]): void {

--- a/client/moduleContentGetter.ts
+++ b/client/moduleContentGetter.ts
@@ -5,28 +5,28 @@ import { ClientContext, sendXQuery, MlClientParameters } from './marklogicClient
 export const listModulesQuery = 'cts:uris()';
 
 export class ModuleContentGetter {
-    private _mlClient: ClientContext;
+    private dbClientContext: ClientContext;
 
-    public constructor(client: ClientContext) {
-        const moduleGetterParams: MlClientParameters = client.params;
+    public constructor(dbClientContext: ClientContext) {
+        const moduleGetterParams: MlClientParameters = dbClientContext.params;
         moduleGetterParams.contentDb = moduleGetterParams.modulesDb;
-        this._mlClient = new ClientContext(moduleGetterParams);
+        this.dbClientContext = new ClientContext(moduleGetterParams);
     }
 
     public host(): string {
-        return this._mlClient.params.host;
+        return this.dbClientContext.params.host;
     }
 
     public port(): number {
-        return this._mlClient.params.port;
+        return this.dbClientContext.params.port;
     }
 
-    public initialize(client: ClientContext): void {
-        this._mlClient = client;
+    public initialize(dbClientContext: ClientContext): void {
+        this.dbClientContext = dbClientContext;
     }
 
     public async provideTextDocumentContent(modulePath: string): Promise<string> {
-        return this._mlClient.databaseClient.read(modulePath)
+        return this.dbClientContext.databaseClient.read(modulePath)
             .result(
                 (fulfill: string[]) => {
                     const moduleContent: string = fulfill[0];
@@ -38,7 +38,7 @@ export class ModuleContentGetter {
     }
 
     public async listModules(): Promise<string[]> {
-        return sendXQuery(this._mlClient, listModulesQuery)
+        return sendXQuery(this.dbClientContext, listModulesQuery)
             .result(
                 (fulfill: Record<string, any>[]) => {
                     return fulfill.map(o => {

--- a/client/test/integration/markLogicIntegrationTestHelper.ts
+++ b/client/test/integration/markLogicIntegrationTestHelper.ts
@@ -139,8 +139,8 @@ export class IntegrationTestHelper {
             });
     }
 
-    async getRid(client: ClientContext, qry: string): Promise<string[]> {
-        const newParams: MlClientParameters = JSON.parse(JSON.stringify(client.params));
+    async getRid(dbClientContext: ClientContext, qry: string): Promise<string[]> {
+        const newParams: MlClientParameters = JSON.parse(JSON.stringify(dbClientContext.params));
         newParams.port = this.managePort;
         const newClient = new ClientContext(newParams);
         return sendJSQuery(newClient, qry)
@@ -155,8 +155,8 @@ export class IntegrationTestHelper {
                 });
     }
 
-    async getRequestStatuses(client: ClientContext, qry: string): Promise<{ requestId: string }[][]> {
-        const newParams: MlClientParameters = JSON.parse(JSON.stringify(client.params));
+    async getRequestStatuses(dbClientContext: ClientContext, qry: string): Promise<{ requestId: string }[][]> {
+        const newParams: MlClientParameters = JSON.parse(JSON.stringify(dbClientContext.params));
         newParams.port = this.managePort;
         const newClient = new ClientContext(newParams);
         return sendJSQuery(newClient, qry)
@@ -171,8 +171,8 @@ export class IntegrationTestHelper {
                 });
     }
 
-    async cancelRequest(client: ClientContext, qry: string): Promise<unknown> {
-        const newParams: MlClientParameters = JSON.parse(JSON.stringify(client.params));
+    async cancelRequest(dbClientContext: ClientContext, qry: string): Promise<unknown> {
+        const newParams: MlClientParameters = JSON.parse(JSON.stringify(dbClientContext.params));
         newParams.port = this.managePort;
         const newClient = new ClientContext(newParams);
         return sendJSQuery(newClient, qry)

--- a/client/test/suite/client.test.ts
+++ b/client/test/suite/client.test.ts
@@ -102,12 +102,12 @@ suite('Extension Test Suite', () => {
         const queryText: string = testOverrideQueryWithGoodJSON();
         const overrides = parseQueryForOverrides(queryText, SJS);
         const gstate = defaultDummyGlobalState();
-        const mlClient1: ClientContext = getDbClient(queryText, SJS, config, gstate);
+        const dbClientContext: ClientContext = getDbClient(queryText, SJS, config, gstate);
 
-        assert.strictEqual(overrides.host, mlClient1.params.host);
+        assert.strictEqual(overrides.host, dbClientContext.params.host);
         // The pwd value in mlClient1.params will always be of type string, so have to cast the expected value
-        assert.strictEqual(mlClient1.params.pwd, String(cfgPwd));
-        assert.strictEqual(mlClient1.params.pathToCa, cfgPca);
+        assert.strictEqual(dbClientContext.params.pwd, String(cfgPwd));
+        assert.strictEqual(dbClientContext.params.pathToCa, cfgPca);
     });
 
     test('override parser should throw if settings are invalid JSON', () => {

--- a/client/vscModuleContentProvider.ts
+++ b/client/vscModuleContentProvider.ts
@@ -20,8 +20,8 @@ export class ModuleContentProvider implements TextDocumentContentProvider {
     private _onDidChange = new EventEmitter<Uri>();
     private _mlModuleGetter: ModuleContentGetter;
 
-    public initialize(client: ClientContext): void {
-        this._mlModuleGetter = new ModuleContentGetter(client);
+    public initialize(dbClientContext: ClientContext): void {
+        this._mlModuleGetter = new ModuleContentGetter(dbClientContext);
     }
 
     async provideTextDocumentContent(uri: Uri): Promise<string> {
@@ -37,14 +37,14 @@ export class ModuleContentProvider implements TextDocumentContentProvider {
     }
 }
 
-export async function pickAndShowModule(mprovider: ModuleContentProvider, client: ClientContext): Promise<void> {
-    mprovider.initialize(client);
+export async function pickAndShowModule(mprovider: ModuleContentProvider, dbClientContext: ClientContext): Promise<void> {
+    mprovider.initialize(dbClientContext);
     mprovider.listModules()
         .then((moduleUris: string[]) => {
             return window.showQuickPick(moduleUris);
         })
         .then((URIstring: string) => {
-            const uri: Uri = encodeLocation(client.params.host, client.params.port, URIstring);
+            const uri: Uri = encodeLocation(dbClientContext.params.host, dbClientContext.params.port, URIstring);
             return uri;
         })
         .then((uri: Uri) => {

--- a/client/vscQueryParameterTools.ts
+++ b/client/vscQueryParameterTools.ts
@@ -77,9 +77,9 @@ export function getDbClient(queryText: string, language: string, cfg: WorkspaceC
     }
     // if there's no existing client in the globalState, instantiate a new one
     if (state.get(MLDBCLIENT) === null) {
-        const newClient: ClientContext = buildNewClient(newParams);
+        const dbClientContext: ClientContext = buildNewClient(newParams);
         try {
-            state.update(MLDBCLIENT, newClient);
+            state.update(MLDBCLIENT, dbClientContext);
             console.debug(`Created new MarklogicClient: ${state.get(MLDBCLIENT)}`);
         } catch (e) {
             console.error('Error: ' + JSON.stringify(e));
@@ -94,12 +94,12 @@ export function getDbClient(queryText: string, language: string, cfg: WorkspaceC
  * user an error.
  */
 export function cascadeOverrideClient(actualQuery: string, language: string, cfg: WorkspaceConfiguration, state: Memento): ClientContext {
-    let client: ClientContext = {} as ClientContext;
+    let dbClientContext: ClientContext = {} as ClientContext;
     try {
-        client = getDbClient(actualQuery, language, cfg, state);
+        dbClientContext = getDbClient(actualQuery, language, cfg, state);
     } catch (error) {
         window.showErrorMessage('could not parse JSON for overrides: ' + error.message);
-        client = getDbClient('', language, cfg, state);
+        dbClientContext = getDbClient('', language, cfg, state);
     }
-    return client;
+    return dbClientContext;
 }


### PR DESCRIPTION
For clarity and consistency, update the name of ClientContext variables to "dbClientContext" throughout the project.
