### PR TITLE
DEVEXP-416: Bug fix when CA file doesn't exist

### DIFF
--- a/client/errorReporter.ts
+++ b/client/errorReporter.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { window } from 'vscode';
+
+export interface MlxprsError {
+    popupMessage: string;
+    reportedMessage: string;
+    stack: string;
+}
+
+export class ErrorReporter {
+    static mlxprsOutput = window.createOutputChannel('mlxprs');
+
+    static reportError(mlxprsError: MlxprsError) {
+        ErrorReporter.mlxprsOutput.appendLine(mlxprsError.reportedMessage);
+        ErrorReporter.mlxprsOutput.appendLine(mlxprsError.stack);
+        ErrorReporter.mlxprsOutput.show();
+        window.showErrorMessage(mlxprsError.popupMessage);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
                         "type": "ml-jsdebugger",
                         "request": "launch",
                         "name": "Evaluate Current JavaScript Module",
-                        "root": "${workspaceFolder}/src/main/ml-modules/roote"
+                        "root": "${workspaceFolder}/src/main/ml-modules/root"
                     },
                     {
                         "type": "ml-jsdebugger",


### PR DESCRIPTION
We verify the existing of the specified CA file before passing control back to VSCode.