### PR TITLE
Put all VSCode configuration settings requests in one place

### DIFF
--- a/client/XQDebugger/xqyDebugConfigProvider.ts
+++ b/client/XQDebugger/xqyDebugConfigProvider.ts
@@ -24,6 +24,7 @@ import {
 import { ErrorReporter, MlxprsError } from '../errorReporter';
 import { MlClientParameters } from '../marklogicClient';
 import { XqyDebugManager, DebugStatusQueryResponse } from './xqyDebugManager';
+import { ConfigurationManager } from '../configurationManager';
 
 
 export class XqyDebugConfiguration implements DebugConfiguration {
@@ -50,19 +51,18 @@ export class XqyDebugConfigurationProvider implements DebugConfigurationProvider
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     private async resolveRemainingDebugConfiguration(folder: WorkspaceFolder | undefined, config: XqyDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
-        const cfg: WorkspaceConfiguration = workspace.getConfiguration();
         const clientParams: MlClientParameters = new MlClientParameters({
-            host: String(cfg.get('marklogic.host')),
-            port: Number(cfg.get('marklogic.port')),
-            managePort: Number(cfg.get('marklogic.managePort')),
-            user: String(cfg.get('marklogic.username')),
-            pwd: String(cfg.get('marklogic.password')),
-            contentDb: String(cfg.get('marklogic.documentsDb')),
-            modulesDb: String(cfg.get('marklogic.modulesDb')),
-            authType: String(cfg.get('marklogic.authType')),
-            ssl: Boolean(cfg.get('marklogic.ssl')),
-            pathToCa: String(cfg.get('marklogic.pathToCa') || ''),
-            rejectUnauthorized: Boolean(cfg.get('marklogic.rejectUnauthorized'))
+            host: String(ConfigurationManager.getHost()),
+            port: Number(ConfigurationManager.getPort()),
+            managePort: Number(ConfigurationManager.getManagePort()),
+            user: String(ConfigurationManager.getUsername()),
+            pwd: String(ConfigurationManager.getPassword()),
+            contentDb: String(ConfigurationManager.getDocumentsDb()),
+            modulesDb: String(ConfigurationManager.getModulesDb()),
+            authType: String(ConfigurationManager.getAuthType()),
+            ssl: Boolean(ConfigurationManager.getSsl()),
+            pathToCa: String(ConfigurationManager.getPathToCa() || ''),
+            rejectUnauthorized: Boolean(ConfigurationManager.getRejectUnauthorized())
         });
         config.clientParams = clientParams;
 

--- a/client/configurationManager.ts
+++ b/client/configurationManager.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+
+export interface MarklogicConfigurationSettings {
+    host?: string;
+    port?: string;
+    managePort?: string;
+    username?: string;
+    password?: string;
+    documentsDb?: string;
+    modulesDb?: string;
+    authType?: string;
+    ssl?: string;
+    pathToCa?: string;
+    rejectUnauthorized?: string;
+}
+
+export class ConfigurationManager {
+
+    private static vscodeConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+    private static overrides: MarklogicConfigurationSettings = {};
+
+    static setOverride(key: string, val: unknown): void {
+        ConfigurationManager.overrides[key] = val;
+    }
+
+    static handleUpdateConfigurationEvent(): void {
+        ConfigurationManager.vscodeConfiguration = vscode.workspace.getConfiguration('marklogic');
+    }
+
+    static getConfigValue(key: string): unknown {
+        if (ConfigurationManager.overrides[key]) {
+            return ConfigurationManager.overrides[key];
+        } else {
+            return ConfigurationManager.vscodeConfiguration.get(key);
+        }
+    }
+
+    static getHost(): string {
+        return ConfigurationManager.getConfigValue('host') as string;
+    }
+
+    static getPort(): string {
+        return ConfigurationManager.getConfigValue('port') as string;
+    }
+
+    static getManagePort(): string {
+        return ConfigurationManager.getConfigValue('managePort') as string;
+    }
+
+    static getUsername(): string {
+        return ConfigurationManager.getConfigValue('username') as string;
+    }
+
+    static getPassword(): string {
+        return ConfigurationManager.getConfigValue('password') as string;
+    }
+
+    static getDocumentsDb(): string {
+        return ConfigurationManager.getConfigValue('documentsDb') as string;
+    }
+
+    static getModulesDb(): string {
+        return ConfigurationManager.getConfigValue('modulesDb') as string;
+    }
+
+    static getAuthType(): string {
+        return ConfigurationManager.getConfigValue('authType') as string;
+    }
+
+    static getSsl(): string {
+        return ConfigurationManager.getConfigValue('ssl') as string;
+    }
+
+    static getPathToCa(): string {
+        return ConfigurationManager.getConfigValue('pathToCa') as string;
+    }
+
+    static getRejectUnauthorized(): string {
+        return ConfigurationManager.getConfigValue('rejectUnauthorized') as string;
+    }
+}

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -31,6 +31,7 @@ import { JsDebugManager } from './JSDebugger/jsDebugManager';
 import { ModuleContentProvider, pickAndShowModule } from './vscModuleContentProvider';
 import { MlxprsStatus } from './mlxprsStatus';
 import { MlxprsWebViewProvider } from './mlxprsWebViewProvider';
+import { ConfigurationManager } from './configurationManager';
 
 
 const MLDBCLIENT = 'mldbClient';
@@ -47,6 +48,11 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.registerTextDocumentContentProvider(
         ModuleContentProvider.scheme, mprovider);
 
+    vscode.workspace.onDidChangeConfiguration(event => {
+        if (event.affectsConfiguration('marklogic')) {
+            ConfigurationManager.handleUpdateConfigurationEvent();
+        }
+    });
 
     const editorQueryEvaluator = new EditorQueryEvaluator(context, provider);
     const sendXQuery = vscode.commands.registerTextEditorCommand(

--- a/client/test/suite/client.test.ts
+++ b/client/test/suite/client.test.ts
@@ -24,12 +24,14 @@ import {
     testOverrideXQueryWithGoodJSON, testOverrideXQueryWithBadJSON, testXQueryWithoutOverrides,
     testOverrideSslParams
 } from './testOverrideQuery';
-import { MLRuntime } from '../../JSDebugger/mlRuntime';
-import { AttachRequestArguments } from '../../JSDebugger/mlDebug';
-import { ClientContext } from '../../marklogicClient';
 import { ClientResponseProvider } from '../../clientResponseProvider';
-import { getDbClient, parseQueryForOverrides } from '../../vscQueryParameterTools';
+import { ConfigurationManager } from '../../configurationManager';
 import { EditorQueryEvaluator } from '../../editorQueryEvaluator';
+import { AttachRequestArguments } from '../../JSDebugger/mlDebug';
+import { MLRuntime } from '../../JSDebugger/mlRuntime';
+import { ClientContext } from '../../marklogicClient';
+import { getDbClient, parseQueryForOverrides } from '../../vscQueryParameterTools';
+import { XqyDebugConfigurationProvider, XqyDebugConfiguration } from '../../XQDebugger/xqyDebugConfigProvider';
 
 const SJS = 'sjs';
 const XQY = 'xqy';
@@ -199,6 +201,14 @@ suite('Extension Test Suite', () => {
                 assert.strictEqual(actualResponseUri.toString(), expectedResponseUri,
                     'the URI should not have a double-dash before the filename section');
             });
+    });
+
+    test('When a debug configuration is requested, but the pathToCa setting points to an unreadable file', async () => {
+        ConfigurationManager.setOverride('pathToCa', '/not/an/existing/file');
+
+        const response = await (new XqyDebugConfigurationProvider()).resolveDebugConfiguration(undefined, new XqyDebugConfiguration(), null);
+        assert.strictEqual(response, undefined, 'the request should return <undefined>');
+        ConfigurationManager.setOverride('pathToCa', null);
     });
 
 });


### PR DESCRIPTION
There are more than 20 places where the extension asks VSCode for settings.

I'm hoping that setting up this singleton will allow me to more easily override specific configuration settings for tests.

Other benefits:
1) All the interactions with VSCode settings are in one place
2) Possibly some caching benefits
