### PR TITLE
DEVEXP-420: Launching Eval fails with self-signed cert

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,13 +67,15 @@ It is recommended to use VSCode as the editor for this package, as it can self-l
     * Note that at this time, the "Attach" commands do not work when debugging the extension from within VSCode. In order to test the "Attach" commands, you will need to build the artifact (.vsix) and use that extension with a different project, and then test manually.
 * Please see the README.md file for information on configuring and working in the test environment
 
-## Debugging the Debugger
-This can be just a little tricky. The best way I've found to test/debug the debugger from withing VSCode is to use the
-"Extension + SJS Server" or "Extension + XQY Server" launch configuration. Using one of these configurations, VSCode will start a new VSCode window where you can have a different project open for testing the debugger. When you use one
-of the "attach" configurations from the second window to attach to a process, the second window also connects to the 
-original VSCode window for debugging purposes. At that point, you have 2 VSCode windows, both attached to a process
-for debugging - the first VSCode is attached to the second VSCode, and the second VSCode is attached to the running copy
-of its project.
+## Debugging the Debugger/Evaluate tasks
+This can be just a little tricky. The preferred mechanism to test/debug the debugger from within VSCode is to use the "Extension + SJS Server" or "Extension + XQY Server" launch configuration. Using one of these configurations, VSCode will start a new VSCode window where you can have a different project open for testing the debugger. VSCode also starts an instance of the Debug Adapter. When you use one of the "attach" or "evaluate" launch.json configurations from the second window to attach to a process, the second window connects to the Debug Adapter in the original VSCode window for debugging purposes. At that point, you have effectively have 3 debug sessions going on:
+1. The debug/launch session in the second window. This, presumably, is the debugger you are working on.
+2. The debug session for the debugger you're working on. Shown as "Launch Extension (preprod)" in the Call Stack view.
+    * This will show the code from the mlxprs project, other than the four source files mentioned in #3.
+3. The debug session for the Debug Adapter. Shown as "Launch <XQY|SJS> Debug Adapter Server" in the Call Stack view.
+    * This will show the code from xqyDebug, xqyRuntime, mlDebug, and mlRuntime
+
+* Note that the Debug Adapter runs in a separate process with no direct access to the VSCode UI or most of the MLXPRS extension code. All interaction between the Debug Adapter and the main extension code must be accomplished via event messages. See the use of onDidReceiveDebugSessionCustomEvent in extension.ts for current use of custom events for error handling.
 
 ### Configuration
 These configurations items are already done, but this should help with understanding how things work for making any future changes.

--- a/client/XQDebugger/xqyDebugConfigProvider.ts
+++ b/client/XQDebugger/xqyDebugConfigProvider.ts
@@ -16,9 +16,9 @@
 
 import { readFileSync } from 'fs';
 import {
-    DebugConfiguration, DebugConfigurationProvider, WorkspaceFolder, CancellationToken, ProviderResult,
-    window, DebugAdapterDescriptorFactory, DebugAdapterExecutable, DebugAdapterDescriptor,
-    DebugSession, QuickPickItem, QuickPickOptions, WorkspaceConfiguration, workspace
+    DebugConfiguration, DebugConfigurationProvider, WorkspaceFolder, CancellationToken,
+    ProviderResult, window, DebugAdapterDescriptorFactory, DebugAdapterExecutable,
+    DebugAdapterDescriptor, DebugSession, QuickPickItem, QuickPickOptions
 } from 'vscode';
 
 import { ErrorReporter, MlxprsError } from '../errorReporter';

--- a/client/XQDebugger/xqyDebugManager.ts
+++ b/client/XQDebugger/xqyDebugManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { QuickPickItem, window } from 'vscode';
+import { DebugSessionCustomEvent, QuickPickItem, window } from 'vscode';
 
 import { ErrorReporter, MlxprsError } from '../errorReporter';
 import { ClientContext, MlClientParameters, sendXQuery, ServerQueryResponse } from '../marklogicClient';
@@ -136,4 +136,11 @@ export class XqyDebugManager {
 
 function appServerSorter(a: QuickPickItem, b: QuickPickItem): number {
     return (a.label.toUpperCase() > b.label.toUpperCase()) ? 1 : ((b.label.toUpperCase() > a.label.toUpperCase()) ? -1 : 0);
+}
+
+export function handleDebugSessionCustomEvent(event: DebugSessionCustomEvent) {
+    console.debug(`Received Debug Session Custom Event: ${JSON.stringify(event)}`);
+    if (event.event === 'MlxprsDebugAdapterError') {
+        ErrorReporter.reportError(event.body['mlxprsError'] as MlxprsError);
+    }
 }

--- a/client/test/integration/Issue69.test.ts
+++ b/client/test/integration/Issue69.test.ts
@@ -42,7 +42,7 @@ suite('Issue 69', async () => {
             hostname: globalConfig.hostname, authType: 'DIGEST',
             ssl: globalConfig.ssl, pathToCa: globalConfig.pathToCa, rejectUnauthorized: globalConfig.rejectUnauthorized
         };
-        const debugClient = integrationTestHelper.debugClient;
+        const debugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
             debugClient.initializeRequest(),
             debugClient.configurationSequence(),

--- a/client/test/integration/Issue70.test.ts
+++ b/client/test/integration/Issue70.test.ts
@@ -46,7 +46,7 @@ suite('Issue 70', async () => {
             hostname: globalConfig.hostname, database: integrationTestHelper.modulesDatabase, modules: integrationTestHelper.modulesDatabase, authType: 'DIGEST',
             ssl: globalConfig.ssl, pathToCa: globalConfig.pathToCa, rejectUnauthorized: globalConfig.rejectUnauthorized
         };
-        const debugClient = integrationTestHelper.debugClient;
+        const debugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
             debugClient.initializeRequest(),
             debugClient.configurationSequence(),

--- a/client/test/integration/index.ts
+++ b/client/test/integration/index.ts
@@ -39,11 +39,11 @@ export async function run(): Promise<void> {
 
     mocha.options.color = true;
     mocha.rootHooks({
-        beforeEach: () => {
-            globalThis.integrationTestHelper.setupEachTest();
+        beforeEach: async () => {
+            await globalThis.integrationTestHelper.setupEachTest();
         },
-        afterEach: () => {
-            globalThis.integrationTestHelper.teardownEachTest();
+        afterEach: async () => {
+            await globalThis.integrationTestHelper.teardownEachTest();
         }
     });
 

--- a/client/test/integration/sjsAdapter.test.ts
+++ b/client/test/integration/sjsAdapter.test.ts
@@ -33,16 +33,16 @@ suite('Testing sjs/xqy boundary in eval/invoke', async () => {
         globalConfig.queryText = fs.readFileSync(globalConfig.program).toString();
         globalConfig.queryText = globalConfig.queryText.replace(integrationTestHelper.modulesDatabaseToken, integrationTestHelper.modulesDatabase);
 
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(globalConfig)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(globalConfig)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: globalConfig.program }, breakpoints: [{ line: 4 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.assertStoppedLocation('breakpoint', { path: globalConfig.program, line: 4 });
-        await debugClient.stepInRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('step', { path: globalConfig.program, line: 6 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: globalConfig.program }, breakpoints: [{ line: 4 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.assertStoppedLocation('breakpoint', { path: globalConfig.program, line: 4 });
+        await jsDebugClient.stepInRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('step', { path: globalConfig.program, line: 6 });
     }).timeout(5000);
 
     test('sjs calling xdmp:eval()', async () => {
@@ -50,16 +50,16 @@ suite('Testing sjs/xqy boundary in eval/invoke', async () => {
         globalConfig.program = Path.join(integrationTestHelper.scriptFolder, 'eval2.sjs');
         globalConfig.queryText = fs.readFileSync(globalConfig.program).toString();
 
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(globalConfig)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(globalConfig)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: globalConfig.program }, breakpoints: [{ line: 4 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.assertStoppedLocation('breakpoint', { path: globalConfig.program, line: 4 });
-        await debugClient.stepInRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('step', { path: globalConfig.program, line: 8 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: globalConfig.program }, breakpoints: [{ line: 4 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.assertStoppedLocation('breakpoint', { path: globalConfig.program, line: 4 });
+        await jsDebugClient.stepInRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('step', { path: globalConfig.program, line: 8 });
     }).timeout(25000);
 
     test('sjs importing xqy', async () => {
@@ -67,16 +67,16 @@ suite('Testing sjs/xqy boundary in eval/invoke', async () => {
         globalConfig.program = Path.join(integrationTestHelper.scriptFolder, 'eval3.sjs');
         globalConfig.queryText = fs.readFileSync(globalConfig.program).toString();
 
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(globalConfig)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(globalConfig)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: globalConfig.program }, breakpoints: [{ line: 4 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.assertStoppedLocation('breakpoint', { path: globalConfig.program, line: 4 });
-        await debugClient.stepInRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('step', { path: globalConfig.program, line: 6 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: globalConfig.program }, breakpoints: [{ line: 4 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.assertStoppedLocation('breakpoint', { path: globalConfig.program, line: 4 });
+        await jsDebugClient.stepInRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('step', { path: globalConfig.program, line: 6 });
     }).timeout(15000);
 
 
@@ -96,16 +96,16 @@ suite('Testing sjs/xqy boundary in eval/invoke', async () => {
             hostname: globalConfig.hostname, database: integrationTestHelper.modulesDatabase, modules: integrationTestHelper.modulesDatabase, authType: 'DIGEST',
             ssl: globalConfig.ssl, pathToCa: globalConfig.pathToCa, rejectUnauthorized: globalConfig.rejectUnauthorized
         };
-        const debugClient: DebugClient = integrationTestHelper.debugClient;
+        const jsDebugClient: DebugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
-            debugClient.initializeRequest(),
-            debugClient.configurationSequence(),
-            debugClient.attachRequest(config as DebugProtocol.AttachRequestArguments)
+            jsDebugClient.initializeRequest(),
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.attachRequest(config as DebugProtocol.AttachRequestArguments)
         ]);
 
-        await debugClient.setBreakpointsRequest({ source: { path: Path.join('/MarkLogic/test', 'jsInvoke-1.sjs') }, breakpoints: [{ line: 3 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        debugClient.assertStoppedLocation('breakpoint', { path: Path.join('/MarkLogic/test', 'jsInvoke-1.sjs'), line: 3 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: Path.join('/MarkLogic/test', 'jsInvoke-1.sjs') }, breakpoints: [{ line: 3 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        jsDebugClient.assertStoppedLocation('breakpoint', { path: Path.join('/MarkLogic/test', 'jsInvoke-1.sjs'), line: 3 });
         JsDebugManager.disconnectFromNamedJsDebugServer(integrationTestHelper.attachServerName);
     }).timeout(10000).skip();
 

--- a/client/test/integration/sjsAdapterBasic.test.ts
+++ b/client/test/integration/sjsAdapterBasic.test.ts
@@ -21,81 +21,81 @@ import { IntegrationTestHelper } from './markLogicIntegrationTestHelper';
 suite('Basic', () => {
     const integrationTestHelper: IntegrationTestHelper = globalThis.integrationTestHelper;
     test('launch a script and it should stop at entry', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         return Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(integrationTestHelper.config),
-            debugClient.assertStoppedLocation('entry', { path: integrationTestHelper.hwPath, line: 1 })
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(integrationTestHelper.config),
+            jsDebugClient.assertStoppedLocation('entry', { path: integrationTestHelper.hwPath, line: 1 })
         ]);
     }).timeout(5000);
 
     test('check stepOver', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(integrationTestHelper.config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(integrationTestHelper.config)
         ]);
         // 2 steps will actually go to the second line
-        await debugClient.nextRequest({ threadId: 1 });
-        await debugClient.waitForEvent('stopped');
-        await debugClient.nextRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('step', { path: integrationTestHelper.hwPath, line: 4 });
+        await jsDebugClient.nextRequest({ threadId: 1 });
+        await jsDebugClient.waitForEvent('stopped');
+        await jsDebugClient.nextRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('step', { path: integrationTestHelper.hwPath, line: 4 });
     }).timeout(5000);
 
     test('set breakpoint', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 4 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('breakpoint', { path: hwPath, line: 4 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 4 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('breakpoint', { path: hwPath, line: 4 });
     }).timeout(5000);
 
     test('check stepInto', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 6 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.waitForEvent('stopped');
-        await debugClient.stepInRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('step', { path: hwPath, line: 12 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 6 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.waitForEvent('stopped');
+        await jsDebugClient.stepInRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('step', { path: hwPath, line: 12 });
     }).timeout(5000);
 
     test('check stepOut', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.waitForEvent('stopped');
-        await debugClient.stepOutRequest({ threadId: 1 });
-        return debugClient.assertStoppedLocation('step', { path: hwPath, line: 7 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.waitForEvent('stopped');
+        await jsDebugClient.stepOutRequest({ threadId: 1 });
+        return jsDebugClient.assertStoppedLocation('step', { path: hwPath, line: 7 });
     }).timeout(5000);
 
     test('check stack trace', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        const stackTrace = await debugClient.assertStoppedLocation('breakpoint', { path: hwPath, line: 12 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        const stackTrace = await jsDebugClient.assertStoppedLocation('breakpoint', { path: hwPath, line: 12 });
         const frame = stackTrace.body.stackFrames[0];
         assert(frame.name, 'loop');
         assert(frame.line, '12');
@@ -103,49 +103,49 @@ suite('Basic', () => {
     }).timeout(5000);
 
     test('check variable', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        const stackTrace = await debugClient.assertStoppedLocation('breakpoint', { path: hwPath, line: 12 });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        const stackTrace = await jsDebugClient.assertStoppedLocation('breakpoint', { path: hwPath, line: 12 });
         const frameId = stackTrace.body.stackFrames[0].id;
-        const scope = await debugClient.scopesRequest({ frameId: frameId });
-        const vars = await debugClient.variablesRequest({ variablesReference: scope.body.scopes[0].variablesReference });
+        const scope = await jsDebugClient.scopesRequest({ frameId: frameId });
+        const vars = await jsDebugClient.variablesRequest({ variablesReference: scope.body.scopes[0].variablesReference });
         return assert.equal(vars.body.variables[0].name, 'ret');
     }).timeout(5000);
 
     test('check evaluate', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.waitForEvent('stopped');
-        const evalResult = await debugClient.evaluateRequest({ expression: 'str' });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 12 }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.waitForEvent('stopped');
+        const evalResult = await jsDebugClient.evaluateRequest({ expression: 'str' });
         return assert.equal(evalResult.body.result, 'Hello World SJS');
     }).timeout(5000);
 
     test('check conditional breakpoint', async () => {
-        const debugClient = integrationTestHelper.debugClient;
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
         const hwPath = integrationTestHelper.hwPath;
         const config = integrationTestHelper.config;
         await Promise.all([
-            debugClient.configurationSequence(),
-            debugClient.launch(config)
+            jsDebugClient.configurationSequence(),
+            jsDebugClient.launch(config)
         ]);
-        await debugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 14, condition: 'i==15' }] });
-        await debugClient.continueRequest({ threadId: 1 });
-        await debugClient.waitForEvent('stopped');
-        const evalResult = await debugClient.evaluateRequest({ expression: 'ret' });
+        await jsDebugClient.setBreakpointsRequest({ source: { path: hwPath }, breakpoints: [{ line: 14, condition: 'i==15' }] });
+        await jsDebugClient.continueRequest({ threadId: 1 });
+        await jsDebugClient.waitForEvent('stopped');
+        const evalResult = await jsDebugClient.evaluateRequest({ expression: 'ret' });
         return assert.equal(evalResult.body.result, '105');
     }).timeout(5000);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,9 +917,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.3.tgz",
-            "integrity": "sha512-Bwxd73pHuYc0cyl7vulPp2I6kAYtmJPkfUivbts7by6wDAVyFdKzGX3AksbvCRyNVFUJu7o2ZTcWXdT90T3qbg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
+            "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
             "dev": true,
             "engines": {
                 "node": ">=14.15.0"
@@ -1712,9 +1712,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.386",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.386.tgz",
-            "integrity": "sha512-w0VD4WR225nuNsz6FokDaqugxzue6iUVBo8QfUrl2Y6nWHxtBUhjWDnUaG/1v5oWeFPLMJAQk3zKHTHW/P8+Og=="
+            "version": "1.4.391",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.391.tgz",
+            "integrity": "sha512-GqydVV1+kUWY5qlEzaw34/hyWTApuQrHiGrcGA2Kk/56nEK44i+YUW45VH43JuZT0Oo7uY8aVtpPhBBZXEWtSA=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1731,9 +1731,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-            "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+            "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -3477,12 +3477,12 @@
             "dev": true
         },
         "node_modules/path-scurry": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
-            "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.8.0.tgz",
+            "integrity": "sha512-IjTrKseM404/UAWA8bBbL3Qp6O2wXkanuIE3seCxBH7ctRuvH1QRawy1N3nVDHGkdeZsjOsSe/8AQBL/VQCy2g==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^9.0.0",
+                "lru-cache": "^9.1.1",
                 "minipass": "^5.0.0"
             },
             "engines": {
@@ -3971,9 +3971,9 @@
             }
         },
         "node_modules/rimraf/node_modules/glob": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.2.tgz",
-            "integrity": "sha512-Xsa0BcxIC6th9UwNjZkhrMtNo/MnyRL8jGCP+uEwhA5oFOCY1f2s1/oNKY47xQ0Bg5nkjsfAEIej1VeH62bDDQ==",
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.3.tgz",
+            "integrity": "sha512-Kb4rfmBVE3eQTAimgmeqc2LwSnN0wIOkkUL6HmxEFxNJ4fHghYHVbFba/HcGcRjE6s9KoMNK3rSOwkL4PioZjg==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
@@ -4146,9 +4146,9 @@
             }
         },
         "node_modules/signal-exit": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.1.tgz",
-            "integrity": "sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -4466,9 +4466,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.17.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.2.tgz",
-            "integrity": "sha512-1D1aGbOF1Mnayq5PvfMc0amAR1y5Z1nrZaGCvI5xsdEfZEVte8okonk02OiaK5fw5hG1GWuuVsakOnpZW8y25A==",
+            "version": "5.17.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.3.tgz",
+            "integrity": "sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
@@ -5796,9 +5796,9 @@
             "requires": {}
         },
         "@webpack-cli/serve": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.3.tgz",
-            "integrity": "sha512-Bwxd73pHuYc0cyl7vulPp2I6kAYtmJPkfUivbts7by6wDAVyFdKzGX3AksbvCRyNVFUJu7o2ZTcWXdT90T3qbg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
+            "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
             "dev": true,
             "requires": {}
         },
@@ -6375,9 +6375,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.386",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.386.tgz",
-            "integrity": "sha512-w0VD4WR225nuNsz6FokDaqugxzue6iUVBo8QfUrl2Y6nWHxtBUhjWDnUaG/1v5oWeFPLMJAQk3zKHTHW/P8+Og=="
+            "version": "1.4.391",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.391.tgz",
+            "integrity": "sha512-GqydVV1+kUWY5qlEzaw34/hyWTApuQrHiGrcGA2Kk/56nEK44i+YUW45VH43JuZT0Oo7uY8aVtpPhBBZXEWtSA=="
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -6394,9 +6394,9 @@
             }
         },
         "enhanced-resolve": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-            "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+            "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
             "requires": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -7698,12 +7698,12 @@
             "dev": true
         },
         "path-scurry": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
-            "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.8.0.tgz",
+            "integrity": "sha512-IjTrKseM404/UAWA8bBbL3Qp6O2wXkanuIE3seCxBH7ctRuvH1QRawy1N3nVDHGkdeZsjOsSe/8AQBL/VQCy2g==",
             "dev": true,
             "requires": {
-                "lru-cache": "^9.0.0",
+                "lru-cache": "^9.1.1",
                 "minipass": "^5.0.0"
             },
             "dependencies": {
@@ -8070,9 +8070,9 @@
                     }
                 },
                 "glob": {
-                    "version": "10.2.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.2.tgz",
-                    "integrity": "sha512-Xsa0BcxIC6th9UwNjZkhrMtNo/MnyRL8jGCP+uEwhA5oFOCY1f2s1/oNKY47xQ0Bg5nkjsfAEIej1VeH62bDDQ==",
+                    "version": "10.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.3.tgz",
+                    "integrity": "sha512-Kb4rfmBVE3eQTAimgmeqc2LwSnN0wIOkkUL6HmxEFxNJ4fHghYHVbFba/HcGcRjE6s9KoMNK3rSOwkL4PioZjg==",
                     "dev": true,
                     "requires": {
                         "foreground-child": "^3.1.0",
@@ -8190,9 +8190,9 @@
             }
         },
         "signal-exit": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.1.tgz",
-            "integrity": "sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
             "dev": true
         },
         "simple-concat": {
@@ -8418,9 +8418,9 @@
             }
         },
         "terser": {
-            "version": "5.17.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.2.tgz",
-            "integrity": "sha512-1D1aGbOF1Mnayq5PvfMc0amAR1y5Z1nrZaGCvI5xsdEfZEVte8okonk02OiaK5fw5hG1GWuuVsakOnpZW8y25A==",
+            "version": "5.17.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.3.tgz",
+            "integrity": "sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==",
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -56,9 +56,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.1.tgz",
-            "integrity": "sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.2.tgz",
+            "integrity": "sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==",
             "dev": true
         },
         "node_modules/@types/vscode": {
@@ -1414,9 +1414,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.1.tgz",
-            "integrity": "sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.2.tgz",
+            "integrity": "sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==",
             "dev": true
         },
         "@types/vscode": {


### PR DESCRIPTION
This one requires manual testing.
The primary changes for this story:
* extension - register the new custom message handler
* xqyDebug - stops the request when launching with ML fails.
* xqyDebugManager - added a handler for custom events from the Debug Adapter, including the new one generated when launching with ML fails.
* xqyRuntime - when launching the query with ML fails, creates a new standard MLXPRS error object and returns that object to the debug client via a custom event.

I attempted to write an integration test for it, but was unable to get the dynamic Debug Client to work properly with the dynamic XQY Debug Adapter.
However, during that attempt, I did some refactoring to the integration test directory that will help with future efforts at XQY debugging integration testing.

Also:
Added some debug-level logging for interactions with the Debug Adapters.