### PR TITLE
DEVEXP-423: Show "Evaluate Current XQuery Module" errors in a popup

### DIFF
--- a/client/JSDebugger/jsDebugManager.ts
+++ b/client/JSDebugger/jsDebugManager.ts
@@ -19,8 +19,9 @@ import * as querystring from 'querystring';
 import * as request from 'request-promise';
 import { QuickPickItem, window, workspace } from 'vscode';
 
-import { ErrorReporter, MlxprsError } from '../errorReporter';
+import { ErrorReporter } from '../errorReporter';
 import { ClientContext, sendXQuery, ServerQueryResponse } from '../marklogicClient';
+import { MlxprsError } from '../mlxprsErrorBuilder';
 import { MlxprsStatus } from '../mlxprsStatus';
 
 

--- a/client/XQDebugger/xqyDebugConfigProvider.ts
+++ b/client/XQDebugger/xqyDebugConfigProvider.ts
@@ -21,8 +21,9 @@ import {
     DebugAdapterDescriptor, DebugSession, QuickPickItem, QuickPickOptions
 } from 'vscode';
 
-import { ErrorReporter, MlxprsError } from '../errorReporter';
+import { ErrorReporter } from '../errorReporter';
 import { MlClientParameters } from '../marklogicClient';
+import { MlxprsError } from '../mlxprsErrorBuilder';
 import { XqyDebugManager, DebugStatusQueryResponse } from './xqyDebugManager';
 import { ConfigurationManager } from '../configurationManager';
 

--- a/client/XQDebugger/xqyDebugManager.ts
+++ b/client/XQDebugger/xqyDebugManager.ts
@@ -16,8 +16,9 @@
 
 import { DebugSessionCustomEvent, QuickPickItem, window } from 'vscode';
 
-import { ErrorReporter, MlxprsError } from '../errorReporter';
+import { ErrorReporter } from '../errorReporter';
 import { ClientContext, MlClientParameters, sendXQuery, ServerQueryResponse } from '../marklogicClient';
+import { MlxprsError } from '../mlxprsErrorBuilder';
 import { MlxprsStatus } from '../mlxprsStatus';
 
 export interface DebugStatusQueryResponse {

--- a/client/editorQueryEvaluator.ts
+++ b/client/editorQueryEvaluator.ts
@@ -24,8 +24,9 @@ import {
 } from 'vscode';
 
 import { ClientResponseProvider, ErrorResultsObject } from './clientResponseProvider';
-import { ErrorReporter, MlxprsError } from './errorReporter';
+import { ErrorReporter } from './errorReporter';
 import { ClientContext, sendJSQuery, sendSparql, sendXQuery, sendRows } from './marklogicClient';
+import { buildMlxprsErrorFromError, MlxprsError } from './mlxprsErrorBuilder';
 import { MlxprsWebViewProvider } from './mlxprsWebViewProvider';
 import { getSparqlQueryForm, getSparqlResponseType } from './sparqlQueryHelper';
 import { cascadeOverrideClient } from './vscQueryParameterTools';
@@ -144,7 +145,7 @@ export class EditorQueryEvaluator {
                     return this.updateResultsViewWithRecordArray(resultsEditorTabIdentifier, recordResults, false);
                 },
                 (error: Error) => {
-                    const mlxprsError: MlxprsError = ErrorReporter.buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
+                    const mlxprsError: MlxprsError = buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
                     ErrorReporter.reportError(mlxprsError);
                     return null;
                 })
@@ -168,7 +169,7 @@ export class EditorQueryEvaluator {
                     return this.updateResultsViewWithRecordArray(resultsEditorTabIdentifier, recordResults, false);
                 },
                 (error: Error) => {
-                    const mlxprsError: MlxprsError = ErrorReporter.buildMlxprsErrorFromError(error, 'Unable to evaluate the query');
+                    const mlxprsError: MlxprsError = buildMlxprsErrorFromError(error, 'Unable to evaluate the query');
                     ErrorReporter.reportError(mlxprsError);
                     return null;
                 })
@@ -201,7 +202,7 @@ export class EditorQueryEvaluator {
                     return this.updateResultsViewWithRecordArray(resultsEditorTabIdentifier, recordResults, false);
                 },
                 (error: Error) => {
-                    const mlxprsError: MlxprsError = ErrorReporter.buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
+                    const mlxprsError: MlxprsError = buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
                     ErrorReporter.reportError(mlxprsError);
                     return null;
                 })
@@ -226,7 +227,7 @@ export class EditorQueryEvaluator {
                     return this.updateResultsViewWithRecordArray(resultsEditorTabIdentifier, [recordResults], true);
                 },
                 (error: Error) => {
-                    const mlxprsError: MlxprsError = ErrorReporter.buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
+                    const mlxprsError: MlxprsError = buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
                     ErrorReporter.reportError(mlxprsError);
                     return null;
                 })
@@ -261,7 +262,7 @@ export class EditorQueryEvaluator {
                 }
             )
             .catch(error => {
-                const mlxprsError: MlxprsError = ErrorReporter.buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
+                const mlxprsError: MlxprsError = buildMlxprsErrorFromError(error, `Unable to evaluate the query: ${error['code']}`);
                 ErrorReporter.reportError(mlxprsError);
                 return null;
             })

--- a/client/errorReporter.ts
+++ b/client/errorReporter.ts
@@ -16,47 +16,10 @@
 
 import { window } from 'vscode';
 
-export interface MlxprsError {
-    popupMessage: string;
-    reportedMessage: string;
-    stack: string;
-    code?: string
-}
+import { MlxprsError } from './mlxprsErrorBuilder';
 
 export class ErrorReporter {
     static mlxprsOutput = window.createOutputChannel('mlxprs');
-
-    static buildMlxprsErrorFromError(error: Error, popupMessageBase: string): MlxprsError {
-        const mlxprsError: MlxprsError = {
-            reportedMessage: 'Unable to determine the error message',
-            stack: 'Unable to find the stack trace in the error object',
-            popupMessage: `${popupMessageBase}`
-        };
-        if (error['reason']) {
-            mlxprsError.popupMessage = `${popupMessageBase}:${error['reason']}`;
-        }
-        if (error.message) {
-            mlxprsError.reportedMessage = error.message;
-            mlxprsError.popupMessage = `${popupMessageBase}:${error.message}`;
-        }
-        if (error.stack) {
-            mlxprsError.stack = error.stack;
-        }
-        if (error['code']) {
-            mlxprsError.code = error['code'];
-        }
-        if (error['statusCode']) {
-            mlxprsError.code = error['statusCode'];
-        }
-        if (error['body']) {
-            if (error['body']['errorResponse']) {
-                mlxprsError.reportedMessage = error['body']['errorResponse']['message'];
-                mlxprsError.code = error['body']['errorResponse']['messageCode'];
-                mlxprsError.popupMessage = `${popupMessageBase}:${error['body']['errorResponse']['status']}`;
-            }
-        }
-        return mlxprsError;
-    }
 
     static reportError(mlxprsError: MlxprsError) {
         ErrorReporter.mlxprsOutput.appendLine(`Error Message: ${mlxprsError.reportedMessage}`);

--- a/client/mlxprsErrorBuilder.ts
+++ b/client/mlxprsErrorBuilder.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MlxprsError {
+    popupMessage: string;
+    reportedMessage: string;
+    stack: string;
+    code?: string
+}
+
+export function buildMlxprsErrorFromError(error: Error, popupMessageBase: string): MlxprsError {
+    const mlxprsError: MlxprsError = {
+        reportedMessage: 'Unable to determine the error message',
+        stack: 'Unable to find the stack trace in the error object',
+        popupMessage: `${popupMessageBase}`
+    };
+    if (error['reason']) {
+        mlxprsError.popupMessage = `${popupMessageBase}:${error['reason']}`;
+    }
+    if (error.message) {
+        mlxprsError.reportedMessage = error.message;
+        mlxprsError.popupMessage = `${popupMessageBase}:${error.message}`;
+    }
+    if (error.stack) {
+        mlxprsError.stack = error.stack;
+    }
+    if (error['code']) {
+        mlxprsError.code = error['code'];
+    }
+    if (error['statusCode']) {
+        mlxprsError.code = error['statusCode'];
+    }
+    if (error['body']) {
+        if (error['body']['errorResponse']) {
+            mlxprsError.reportedMessage = error['body']['errorResponse']['message'];
+            mlxprsError.code = error['body']['errorResponse']['messageCode'];
+            if (error['body']['errorResponse']['status']) {
+                mlxprsError.popupMessage = `${popupMessageBase}:${error['body']['errorResponse']['status']}`;
+            }
+            if (error['body']['errorResponse']['message']) {
+                mlxprsError.popupMessage = `${popupMessageBase}:${error['body']['errorResponse']['message']}`;
+            }
+            if (error['body']['errorResponse']['messageCode']) {
+                mlxprsError.popupMessage = `${popupMessageBase}:${error['body']['errorResponse']['messageCode']}`;
+            }
+        }
+    }
+    return mlxprsError;
+}

--- a/client/vscQueryParameterTools.ts
+++ b/client/vscQueryParameterTools.ts
@@ -19,8 +19,9 @@
 import * as esprima from 'esprima';
 import { Memento, WorkspaceConfiguration, window } from 'vscode';
 
-import { ErrorReporter, MlxprsError } from './errorReporter';
+import { ErrorReporter } from './errorReporter';
 import { SJS, XQY, parseXQueryForOverrides, MLSETTINGSFLAG, ClientContext, MlClientParameters, MLDBCLIENT } from './marklogicClient';
+import { MlxprsError } from './mlxprsErrorBuilder';
 
 /**
  * In SJS/XQuery queries, you can override the VS Code mxprs settings in a comment.


### PR DESCRIPTION
Updated and standardized the way the XQY debugger reports errors.

This also required some refactoring to the MlxprsError object. It was moved to a new file that is independent of the 'vscode' library so that it could be more easily included in the Debug Client code.
