### PR TITLE
DEVEXP-424: Show "Evaluate Current JavaScript Module" errors in a popup

### DIFF
--- a/client/test/integration/index.ts
+++ b/client/test/integration/index.ts
@@ -52,7 +52,7 @@ export async function run(): Promise<void> {
 
     return new Promise((c, e) => {
         // We can change the value below to run specific test files.
-        // glob('integration/sslFailures.test.js', { cwd: testsRoot }, (err, files) => {
+        // glob('integration/sjsFailures.test.js', { cwd: testsRoot }, (err, files) => {
         glob('integration/**.test.js', { cwd: testsRoot }, (err, files) => {
             console.debug(JSON.stringify(files));
             vscode.window.showInformationMessage(JSON.stringify(files));

--- a/client/test/integration/markLogicIntegrationTestHelper.ts
+++ b/client/test/integration/markLogicIntegrationTestHelper.ts
@@ -136,16 +136,18 @@ export class IntegrationTestHelper {
         this.jsDebugClient = new DebugClient('node', this.jsDebugExec, 'node');
 
         return Promise.all([
+            // Include the port parameter when using the debugger with the "Launch ??? Debug Adapter Server" launch configuration in launch.json
+            // This is useful when you want to debug the adapter code while running a test
+            // this.jsDebugClient.start(4711),
+
+            // Exclude the port parameter when you want the test to start/stop a Debug Adapter Server on it's own.
+            // This is useful when the tests are automated.
             this.jsDebugClient.start(),
+
 
             // We have not been successful creating an XQY Debug Client for the automated integration tests.
             // However, the information below will be useful if we try again in the future.
-            //
-            // Include the port parameter when using the debugger with the "Launch ??? Debug Adapter Server" launch configuration in launch.json
-            // This is useful when you want to debug the adapter code while running a test
             // this.xqyDebugClient.start(4712)
-            // Exclude the port parameter when you want the test to start/stop a Debug Adapter Server on it's own.
-            // This is useful when the tests are automated.
             // this.xqyDebugClient.start()
         ]);
     }

--- a/client/test/integration/sjsFailures.test.ts
+++ b/client/test/integration/sjsFailures.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import * as assert from 'assert';
+
+import { IntegrationTestHelper } from './markLogicIntegrationTestHelper';
+
+
+suite('Testing SJS Debug failures in various scenarios, including a couple of successes to verify', async () => {
+    const integrationTestHelper: IntegrationTestHelper = globalThis.integrationTestHelper;
+
+    test('Attempt to Launch Eval Debug with SSL OFF in extension and in MarkLogic', async () => {
+        const globalConfig = integrationTestHelper.config;
+        globalConfig.queryText = '"A" + 1;';
+
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
+        let launchResponse = null;
+        await Promise.all([
+            jsDebugClient.configurationSequence(),
+            launchResponse = await jsDebugClient.launch(globalConfig)
+        ]);
+        assert.equal(launchResponse.body, null, 'Should work properly');
+    }).timeout(5000);
+
+    test('Attempt to Launch Eval Debug with SSL ON in extension, but OFF in MarkLogic', async () => {
+        const globalConfig = integrationTestHelper.config;
+        globalConfig.ssl = true;
+        globalConfig.queryText = '"A" + 1;';
+
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
+        let launchResponse = null;
+        await Promise.all([
+            jsDebugClient.configurationSequence(),
+            launchResponse = await jsDebugClient.launch(globalConfig)
+        ]);
+        assert.equal(launchResponse.body.name, 'RequestError', 'The response should contain an error object with the expected name.');
+    }).timeout(5000);
+
+    test('Attempt to Launch Eval Debug with SSL OFF in extension, but ON in MarkLogic', async () => {
+        const globalConfig = integrationTestHelper.config;
+        globalConfig.port = 8057;
+        globalConfig.managePort = 8052;
+        globalConfig.queryText = '"A" + 1;';
+
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
+        let launchResponse = null;
+        await Promise.all([
+            jsDebugClient.configurationSequence(),
+            launchResponse = await jsDebugClient.launch(globalConfig)
+        ]);
+        assert.equal(launchResponse.body.name, 'RequestError', 'The response should contain an error object with the expected name.');
+    }).timeout(5000);
+
+    test('Attempt to Launch Eval Debug with SSL ON in extension and in MarkLogic', async () => {
+        const globalConfig = integrationTestHelper.config;
+        globalConfig.port = 8057;
+        globalConfig.managePort = 8052;
+        globalConfig.ssl = true;
+        globalConfig.queryText = '"A" + 1;';
+
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
+        let launchResponse = null;
+        await Promise.all([
+            jsDebugClient.configurationSequence(),
+            launchResponse = await jsDebugClient.launch(globalConfig)
+        ]);
+        assert.equal(launchResponse.body, null, 'Should work properly');
+    }).timeout(10000);
+
+    test('Attempt to Launch Eval Debug with malformed JavaScript', async () => {
+        const globalConfig = integrationTestHelper.config;
+        globalConfig.queryText = 'aconst gibberish;';
+
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
+        let launchResponse = null;
+        await Promise.all([
+            jsDebugClient.configurationSequence(),
+            launchResponse = await jsDebugClient.launch(globalConfig)
+        ]);
+        assert.equal(launchResponse.body.name, 'StatusCodeError', 'The response should contain an error object with the expected name.');
+    }).timeout(10000);
+
+    test('Attempt to Launch Eval Debug with a bad password', async () => {
+        const globalConfig = integrationTestHelper.config;
+        globalConfig.password = 'qwerty';
+
+        const jsDebugClient = integrationTestHelper.jsDebugClient;
+        let launchResponse = null;
+        await Promise.all([
+            jsDebugClient.configurationSequence(),
+            launchResponse = await jsDebugClient.launch(globalConfig)
+        ]);
+        assert.equal(launchResponse.body.name, 'StatusCodeError', 'The response should contain an error object with the expected name.');
+    }).timeout(5000);
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,9 +1309,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001487",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-            "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
+            "version": "1.0.30001488",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+            "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1703,9 +1703,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.396",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.396.tgz",
-            "integrity": "sha512-pqKTdqp/c5vsrc0xUPYXTDBo9ixZuGY8es4ZOjjd6HD6bFYbu5QA09VoW3fkY4LF1T0zYk86lN6bZnNlBuOpdQ=="
+            "version": "1.4.399",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz",
+            "integrity": "sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -2610,9 +2610,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -3114,9 +3114,9 @@
             }
         },
         "node_modules/minipass": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
-            "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3480,13 +3480,13 @@
             "dev": true
         },
         "node_modules/path-scurry": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.1.tgz",
-            "integrity": "sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+            "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.0"
+                "minipass": "^5.0.0 || ^6.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3974,15 +3974,15 @@
             }
         },
         "node_modules/rimraf/node_modules/glob": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.4.tgz",
-            "integrity": "sha512-fDboBse/sl1oXSLhIp0FcCJgzW9KmhC/q8ULTKC82zc+DL3TL7FNb8qlt5qqXN53MsKEUSIcb+7DLmEygOE5Yw==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.5.tgz",
+            "integrity": "sha512-Gj+dFYPZ5hc5dazjXzB0iHg2jKWJZYMjITXYPBRQ/xc2Buw7H0BINknRTwURJ6IC6MEFpYbLvtgVb3qD+DwyuA==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^2.0.3",
                 "minimatch": "^9.0.0",
-                "minipass": "^5.0.0 || ^6.0.0",
+                "minipass": "^5.0.0 || ^6.0.2",
                 "path-scurry": "^1.7.0"
             },
             "bin": {
@@ -4486,9 +4486,9 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.8",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
-            "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
+            "version": "5.3.9",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+            "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",
@@ -6069,9 +6069,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001487",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-            "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA=="
+            "version": "1.0.30001488",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+            "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ=="
         },
         "caseless": {
             "version": "0.12.0",
@@ -6367,9 +6367,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.396",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.396.tgz",
-            "integrity": "sha512-pqKTdqp/c5vsrc0xUPYXTDBo9ixZuGY8es4ZOjjd6HD6bFYbu5QA09VoW3fkY4LF1T0zYk86lN6bZnNlBuOpdQ=="
+            "version": "1.4.399",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz",
+            "integrity": "sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A=="
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -7025,9 +7025,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -7404,9 +7404,9 @@
             "optional": true
         },
         "minipass": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
-            "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
             "dev": true
         },
         "mkdirp-classic": {
@@ -7696,13 +7696,13 @@
             "dev": true
         },
         "path-scurry": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.1.tgz",
-            "integrity": "sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+            "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
             "dev": true,
             "requires": {
                 "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.0"
+                "minipass": "^5.0.0 || ^6.0.2"
             },
             "dependencies": {
                 "lru-cache": {
@@ -8068,15 +8068,15 @@
                     }
                 },
                 "glob": {
-                    "version": "10.2.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.4.tgz",
-                    "integrity": "sha512-fDboBse/sl1oXSLhIp0FcCJgzW9KmhC/q8ULTKC82zc+DL3TL7FNb8qlt5qqXN53MsKEUSIcb+7DLmEygOE5Yw==",
+                    "version": "10.2.5",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.5.tgz",
+                    "integrity": "sha512-Gj+dFYPZ5hc5dazjXzB0iHg2jKWJZYMjITXYPBRQ/xc2Buw7H0BINknRTwURJ6IC6MEFpYbLvtgVb3qD+DwyuA==",
                     "dev": true,
                     "requires": {
                         "foreground-child": "^3.1.0",
                         "jackspeak": "^2.0.3",
                         "minimatch": "^9.0.0",
-                        "minipass": "^5.0.0 || ^6.0.0",
+                        "minipass": "^5.0.0 || ^6.0.2",
                         "path-scurry": "^1.7.0"
                     }
                 },
@@ -8427,9 +8427,9 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.3.8",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
-            "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
+            "version": "5.3.9",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+            "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
             "requires": {
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -56,9 +56,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.1.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.5.tgz",
-            "integrity": "sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg==",
+            "version": "20.2.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.0.tgz",
+            "integrity": "sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==",
             "dev": true
         },
         "node_modules/@types/vscode": {
@@ -1414,9 +1414,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.1.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.5.tgz",
-            "integrity": "sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg==",
+            "version": "20.2.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.0.tgz",
+            "integrity": "sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==",
             "dev": true
         },
         "@types/vscode": {

--- a/test-app/.vscode/launch.json
+++ b/test-app/.vscode/launch.json
@@ -8,14 +8,16 @@
             "type": "ml-jsdebugger",
             "request": "launch",
             "name": "Evaluate Current JavaScript Module",
-            "root": "${workspaceFolder}/src/main/ml-modules/root"
+            "root": "${workspaceFolder}/src/main/ml-modules/root",
+            // "debugServer": 4711
         },
         {
             "type": "ml-jsdebugger",
             "request": "launch",
             "name": "Evaluate Specific JavaScript Module",
             "root": "${workspaceFolder}/src/main/ml-modules/root",
-            "program": "/Users/pbarber/Documents/workspaces/engineering/mlxprsStuff/mlxprsSampleProject/src/main/ml-modules/root/javascript/launch.sjs"
+            "program": "/Users/pbarber/Documents/workspaces/engineering/mlxprsStuff/mlxprsSampleProject/src/main/ml-modules/root/javascript/launch.sjs",
+            // "debugServer": 4711
         },
         {
             "type": "ml-jsdebugger",
@@ -38,6 +40,7 @@
             "name": "Evaluate Specific XQuery Module",
             "root": "${workspaceFolder}/src/main/ml-modules/root",
             "program": "/Users/pbarber/Documents/workspaces/engineering/mlxprsStuff/mlxprsSampleProject/src/main/ml-modules/root/xquery/longTest.xqy"
+            // "debugServer": 4712
         },
         {
             "type": "xquery-ml",

--- a/test-app/.vscode/settings.json
+++ b/test-app/.vscode/settings.json
@@ -5,5 +5,6 @@
     "marklogic.documentsDb": "mlxprs-test-content",
     "marklogic.modulesDb": "mlxprs-test-modules",
     "marklogic.rejectUnauthorized": false,
-    "marklogic.ssl": false
+    "marklogic.ssl": false,
+    "marklogic.managePort": 8002
 }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -3,3 +3,11 @@ plugins {
   id 'net.saliman.properties' version '1.5.2'
   id "com.marklogic.ml-gradle" version "4.5.0"
 }
+
+ext {
+    def command = new com.marklogic.appdeployer.command.security.GenerateTemporaryCertificateCommand()
+    command.setTemplateIdOrName("mlxprs-ssl-certificate-template")
+    command.setCommonName("localhost")
+    command.setValidFor(365)
+    mlAppDeployer.commands.add(command)
+}

--- a/test-app/src/main/ml-config/servers/digest-ssl-server.json
+++ b/test-app/src/main/ml-config/servers/digest-ssl-server.json
@@ -1,12 +1,14 @@
 {
     "server-type": "http",
     "server-name": "mlxprs-ssl-test",
-    "authentication": "digest",
+    "root": "/",
     "port": 8057,
     "modules-database": "mlxprs-test-modules",
     "content-database": "mlxprs-test-content",
-    "root": "/",
-    "url-rewriter": "/MarkLogic/rest-api/rewriter.xml",
+    "authentication": "digest",
     "error-handler": "/MarkLogic/rest-api/error-handler.xqy",
-    "ssl-certificate-template": "mlxprs-ssl-certificate-template"
+    "url-rewriter": "/MarkLogic/rest-api/rewriter.xml",
+    "rewrite-resolves-globally": true,
+    "ssl-certificate-template": "mlxprs-ssl-certificate-template",
+    "ssl-require-client-certificate": false
 }

--- a/test-app/src/main/ml-config/servers/manage-ssl-server.json
+++ b/test-app/src/main/ml-config/servers/manage-ssl-server.json
@@ -1,0 +1,13 @@
+{
+    "server-type": "http",
+    "server-name": "Manage-ssl",
+    "root": "Apps/",
+    "port": 8052,
+    "content-database": "App-Services",
+    "authentication": "digest",
+    "error-handler": "manage/error-handler.xqy",
+    "url-rewriter": "/MarkLogic/manage/rewriter.xml",
+    "rewrite-resolves-globally": true,
+    "ssl-certificate-template": "mlxprs-ssl-certificate-template",
+    "ssl-require-client-certificate": false
+}


### PR DESCRIPTION
Also added a clone of the "Manage" app-server with SSL turned on to facilitate testing.

If you attempt to run the automated tests locally, note the "note" that was added to the CONTRIB file.