### PR TITLE
Updated jsDebugManager - covered by existing tests

### DIFF
--- a/client/JSDebugger/mlRuntime.ts
+++ b/client/JSDebugger/mlRuntime.ts
@@ -180,14 +180,14 @@ export class MLRuntime extends EventEmitter {
     }
 
     public setBreakPoint(location: MLbreakPoint): Promise<string> {
-        let body = `url=${location.url}&lno=${location.line}`;
+        let urlParameters = `url=${location.url}&lno=${location.line}`;
         if (location.column) {
-            body = body.concat(`&cno=${location.column}`);
+            urlParameters = urlParameters.concat(`&cno=${location.column}`);
         }
         if (location.condition) {
-            body = body.concat(`&condition=${location.condition}`);
+            urlParameters = urlParameters.concat(`&condition=${location.condition}`);
         }
-        return this._sendMLdebugRequestPOST('set-breakpoint', body);
+        return this._sendMLdebugRequestPOST('set-breakpoint', '', urlParameters);
     }
 
     public removeBreakPoint(location: MLbreakPoint): Promise<string> {
@@ -200,7 +200,7 @@ export class MLRuntime extends EventEmitter {
 
     public wait(): Promise<string> {
         const body = 'time-out=5';
-        return this._sendMLdebugRequestPOST('wait', body);
+        return this._sendMLdebugRequestPOST('wait', '', body);
     }
 
     public evaluateOnCallFrame(expr: string, cid?: string): Promise<string> {
@@ -224,7 +224,7 @@ export class MLRuntime extends EventEmitter {
 
     public terminate(): Promise<string> {
         const data = 'server-name=TaskServer';
-        return this._sendMLdebugRequestPOST('request-cancel', data);
+        return this._sendMLdebugRequestPOST('request-cancel', '', data);
     }
 
     public async waitTillPaused(): Promise<string> {
@@ -247,13 +247,17 @@ export class MLRuntime extends EventEmitter {
     //---- helpers
 
     private _sendMLdebugRequestPOST(
-        module: string, body?: string
+        module: string, body?: string, urlParameters?: string
     ): Promise<string> {
         const manageClient = newMarklogicManageClient(this.dbClientContext, this.managePort);
 
+        let endpoint = `/jsdbg/v1/${module}/${this._rid}`;
+        if (urlParameters) {
+            endpoint = `${endpoint}?${urlParameters}`;
+        }
         return new Promise((resolve, reject) => {
             manageClient.databaseClient.internal.sendRequest(
-                `/jsdbg/v1/${module}/${this._rid}`,
+                endpoint,
                 (requestOptions: ml.RequestOptions) => {
                     requestOptions.method = 'POST';
                     requestOptions.headers = { 'X-Error-Accept': 'application/json' };

--- a/client/test/integration/connectAndDisconnect.test.ts
+++ b/client/test/integration/connectAndDisconnect.test.ts
@@ -28,7 +28,6 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
     const dbClientContext: ClientContext = integrationTestHelper.mlClient;
     const mlClientWithBadSsl: ClientContext = integrationTestHelper.mlClientWithBadSsl;
     const attachServerName: string = integrationTestHelper.attachServerName;
-    await JsDebugManager.disconnectFromNamedJsDebugServer(attachServerName);
     const showErrorPopup = integrationTestHelper.showErrorPopup;
     const mlClientWithSslWithRejectUnauthorized: ClientContext = integrationTestHelper.mlClientWithSslWithRejectUnauthorized;
 
@@ -43,6 +42,7 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
 
     test('When there is a single "connected" app-server, and no SSL settings are configured', async () => {
         await JsDebugManager.connectToNamedJsDebugServer(attachServerName);
+        globalThis.integrationTestHelper.attachedToServer = true;
 
         showErrorPopup.resetHistory();
         const connectedAppServers: QuickPickItem[] = await JsDebugManager.getFilteredListOfJsAppServers(dbClientContext, 'true');
@@ -50,7 +50,6 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
         assert.strictEqual(connectedAppServers.length, 1, 'Then the response array should have 1 server listed');
         assert.strictEqual(connectedAppServers[0].label, attachServerName,
             `Then the label of the server in the response array match ${attachServerName}`);
-        JsDebugManager.disconnectFromNamedJsDebugServer(attachServerName);
     }).timeout(5000);
 
 

--- a/client/test/integration/marklogicClient.test.ts
+++ b/client/test/integration/marklogicClient.test.ts
@@ -25,7 +25,6 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
     const dbClientContext: ClientContext = integrationTestHelper.mlClient;
     const managePort = integrationTestHelper.managePort;
     const attachServerName: string = integrationTestHelper.attachServerName;
-    await JsDebugManager.disconnectFromNamedJsDebugServer(attachServerName);
 
     test('When there are no "connected" app-servers initially', async () => {
         const disconnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, 'false');
@@ -35,6 +34,7 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
         assert.equal(connectedAppServers.length, 0, 'no app servers should be returned for this list');
 
         await JsDebugManager.connectToNamedJsDebugServer(attachServerName);
+        globalThis.integrationTestHelper.attachedToServer = true;
 
         const updatedDisconnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, 'false');
         assert.equal(updatedDisconnectedAppServers.length + 1, disconnectedAppServers.length,

--- a/client/test/integration/sjsAdapter.test.ts
+++ b/client/test/integration/sjsAdapter.test.ts
@@ -83,6 +83,7 @@ suite('Testing sjs/xqy boundary in eval/invoke', async () => {
     test('xqy calling xdmp.invoke()', async () => {
         const globalConfig = integrationTestHelper.config;
         await JsDebugManager.connectToNamedJsDebugServer(integrationTestHelper.attachServerName);
+        globalThis.integrationTestHelper.attachedToServer = true;
 
         CP.exec(`curl --anyauth -k --user ${globalConfig.username}:${globalConfig.password} -i -X POST -H "Content-type: application/x-www-form-urlencoded" \
                 http${globalConfig.ssl ? 's' : ''}://${globalConfig.hostname}:${integrationTestHelper.serverPortForAttaching}/LATEST/invoke --data-urlencode module=/MarkLogic/test/invoke1.xqy`);
@@ -107,7 +108,6 @@ suite('Testing sjs/xqy boundary in eval/invoke', async () => {
         await jsDebugClient.setBreakpointsRequest({ source: { path: Path.join('/MarkLogic/test', 'jsInvoke-1.sjs') }, breakpoints: [{ line: 3 }] });
         await jsDebugClient.continueRequest({ threadId: 1 });
         jsDebugClient.assertStoppedLocation('breakpoint', { path: Path.join('/MarkLogic/test', 'jsInvoke-1.sjs'), line: 3 });
-        JsDebugManager.disconnectFromNamedJsDebugServer(integrationTestHelper.attachServerName);
     }).timeout(10000).skip();
 
 });


### PR DESCRIPTION
This replaces the uses of "requests" in jsDebugManager that are covered by existing tests.

Deletes some dead code.

It also includes some minor refactoring and bug fixes based on lessons learned while working on this round of replacements.