### PR TITLE
DEVEXP-393 - Run marklogic-unit-test module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ _Develop, run, and debug code for MarkLogic in the popular VS Code IDE_
 
 * Syntax highlighting and IntelliSense for MarkLogic Server-Side JavaScript and XQuery
 * Interactive debugging of JavaScript and XQuery running in MarkLogic, including attaching to in-flight requests and inspecting live variables
-* Real-time query evaluation of JavaScript, XQuery, SQL, and SPARQL against a live Data Hub Service or MarkLogic instance
+* Real-time query evaluation of JavaScript, XQuery, SQL, SPARQL, and Optic against a MarkLogic instance
 * View modules (read-only) in the editor
+* Run [marklogic-unit-test module](https://github.com/marklogic-community/marklogic-unit-test)
 
 _JavaScript debugging requires version 2.0.0+ of the MarkLogic extension and [MarkLogic 10.0-4+](https://developer.marklogic.com/products/marklogic-server/10.0)._
 
@@ -42,16 +43,28 @@ Note that marklogic.documentsDb *must* be declared in order to attach to remote 
 You can also set `marklogic.authType` to `DIGEST` or `BASIC`. Digest is the default,
 and works even if the server is running basic authentication.
 
-### Connect and query
 
-To evaluate JavaScript
+### Evaluate Queries
 
-1. Type a valid JavaScript query in the editor.
-2. Open the command palette (<kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>P</kbd>)
-3. Select `MarkLogic: Eval JS`
+To evaluate JavaScript, XQuery, SQL, or SPARQL:
 
-Query results will open in a new document in the current workspace.
-`Eval XQuery`, `Eval SQL` and `Eval SPARQL` work the same way.
+1. Type a valid query in the editor.
+2. Open the command palette (<kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>P</kbd>).
+3. Select `MarkLogic: Eval JS`, `MarkLogic: Eval XQuery`, `MarkLogic: Eval SQL`, or `MarkLogic: Eval SPARQL` - depending on the type of query.
+
+Query results will apper in the `MLXPRS: RESULTS` tab in the bottom panel, or open in a new editor tab - depending on the value of the `Marklogic: Results In Editor Tab` setting.
+
+
+### Submit Optic Queries
+
+To run an Optic query (either DSL or serialized):
+
+1. Type a valid query in the editor.
+2. Open the command palette (<kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>P</kbd>).
+3. Select one of the `MarkLogic: Submit Optic query - <Response Format>` commands, depending on the desired response format.
+
+Query results will apper in the `MLXPRS: RESULTS` tab in the bottom panel, or open in a new editor tab - depending on the value of the `Marklogic: Results In Editor Tab` setting.
+
 
 ### Inspect a module
 
@@ -62,6 +75,18 @@ To view a module from the configured modules database:
 3. Choose the module you'd like to view from the resulting list. The list searches and filters as you type.
 
 The module will appear read-only in a new text buffer.
+
+
+### Run marklogic-unit-test module
+
+This plugin provides a convenient method for running a [marklogic-unit-test module](https://marklogic-community.github.io/marklogic-unit-test/) within your MarkLogic server. To get started, your test suites and files must be organized under a "src/test/ml-modules/root/test/suites" directory. See this [ml-gradle sample project](https://github.com/marklogic/ml-gradle/tree/master/examples/unit-test-project) for an example of how to setup the project to use marklogic-unit-test. Additionally, you need to set the `Marklogic: Test Port` setting to the port number of the App Server that can run your unit tests. Finally, to run a test file:
+
+1. In an editor tab, open the test file that you wish to be executed.
+2. Open the command palette (<kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>P</kbd>)
+3. Select `MarkLogic: Run marklogic-unit-test module` from the list
+
+The results of the tests will appear in the `MLXPRS: RESULTS` tab in the bottom panel.
+
 
 ### SSL Configuration
 
@@ -235,9 +260,9 @@ Attach mode intercepts a paused request in a given *debug server*, an app server
 
 Connecting a server will automatically pause all requests so that you can attach the debugger. When you're done, use either <kbd>MarkLogic: Disconnect...</kbd> command to disable debugging and resume handling requests as normal.
 
-**Note: Only requests that are launched after a server is connected/made debug server can be attached.**
-
 Once you start debugging, a dropdown menu will pop up listing all paused requests on the debug server. Choose the one you want to debug.
+
+**Note: Only requests that are launched after a server is connected/made debug server can be attached.**
 
 ![Attach screenshot](images/attach_screenshot.png "attach screenshot")
 

--- a/client/editorQueryEvaluator.ts
+++ b/client/editorQueryEvaluator.ts
@@ -16,7 +16,6 @@
 
 'use strict';
 
-import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import * as ml from 'marklogic';
 import {
     ExtensionContext, TextDocument, TextEdit, TextEditor, Uri,
@@ -336,7 +335,7 @@ export class EditorQueryEvaluator {
     private static requestMlxprsWebviewUpdateWithErrorResultsObject(response: ErrorResultsObject): void {
         if (EditorQueryEvaluator.mlxprsWebViewProvider) {
             EditorQueryEvaluator.focusOnResultsView();
-            const stringResults = EditorQueryEvaluator.convertTextResponseToHtml(JSON.stringify(response, null, 2));
+            const stringResults = MlxprsWebViewProvider.convertTextResponseToHtml(JSON.stringify(response, null, 2));
             EditorQueryEvaluator.mlxprsWebViewProvider.updateViewContent(stringResults);
         }
     }
@@ -346,11 +345,11 @@ export class EditorQueryEvaluator {
             EditorQueryEvaluator.focusOnResultsView();
             let stringResults = '';
             if (resultFormat === 'json') {
-                stringResults = EditorQueryEvaluator.convertTextResponseToHtml(JSON.stringify(response, null, 2));
+                stringResults = MlxprsWebViewProvider.convertTextResponseToHtml(JSON.stringify(response, null, 2));
             } else if (resultFormat === 'xml') {
-                stringResults = EditorQueryEvaluator.convertXmlResponseToHtml(response.toString());
+                stringResults = MlxprsWebViewProvider.convertXmlResponseToHtml(response.toString());
             } else {
-                stringResults = EditorQueryEvaluator.convertTextResponseToHtml(response.toString());
+                stringResults = MlxprsWebViewProvider.convertTextResponseToHtml(response.toString());
             }
             EditorQueryEvaluator.mlxprsWebViewProvider.updateViewContent(stringResults);
         }
@@ -374,46 +373,27 @@ export class EditorQueryEvaluator {
 
     private static convertRecordToHtml(record: Record<string, any>, contentType?: string): string {
         if (record['format'] === 'xml') {
-            return EditorQueryEvaluator.convertXmlResponseToHtml(record['value']);
+            return MlxprsWebViewProvider.convertXmlResponseToHtml(record['value']);
         }
         if (record['format'] === 'text' && record['datatype'] === 'node()') {
-            return EditorQueryEvaluator.convertTextResponseToHtml(ClientResponseProvider.decodeBinaryText(record['value']));
+            return MlxprsWebViewProvider.convertTextResponseToHtml(ClientResponseProvider.decodeBinaryText(record['value']));
         }
         if (record['format'] === 'text' && record['datatype'] === 'other') {
-            return EditorQueryEvaluator.convertTextResponseToHtml(record['value']);
+            return MlxprsWebViewProvider.convertTextResponseToHtml(record['value']);
         }
         if (record['head']) {
-            return EditorQueryEvaluator.convertTextResponseToHtml(JSON.stringify(record, null, 2));
+            return MlxprsWebViewProvider.convertTextResponseToHtml(JSON.stringify(record, null, 2));
         }
         if (record['value']) {
-            return EditorQueryEvaluator.convertTextResponseToHtml(JSON.stringify(record['value'], null, 2));
+            return MlxprsWebViewProvider.convertTextResponseToHtml(JSON.stringify(record['value'], null, 2));
         }
         if (contentType === 'application/xml') {
             let rawXml = record.toString();
             if (rawXml.endsWith('\n')) {
                 rawXml = rawXml.substring(0, rawXml.length - 1);
             }
-            return EditorQueryEvaluator.convertXmlResponseToHtml(rawXml);
+            return MlxprsWebViewProvider.convertXmlResponseToHtml(rawXml);
         }
-        return EditorQueryEvaluator.convertTextResponseToHtml(record.toString());
-    }
-
-    private static convertXmlResponseToHtml(rawXml: string): string {
-        const options = {
-            ignoreAttributes: false,
-            attributeNamePrefix: '@_',
-            format: true
-        };
-        const parser = new XMLParser(options);
-        const jObj = parser.parse(rawXml);
-        const builder = new XMLBuilder(options);
-        const formattedXml = builder.build(jObj);
-
-        const lineCount = (formattedXml.match(/\n/g) || []).length + 1;
-        return `<textarea white-space: pre; rows="${lineCount}" cols="40" style="width: 100%; color: #fff;background: transparent;border:none;">` + formattedXml + '</textarea>';
-    }
-
-    private static convertTextResponseToHtml(text: string): string {
-        return '<pre>' + text + '</pre>';
+        return MlxprsWebViewProvider.convertTextResponseToHtml(record.toString());
     }
 }

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -27,6 +27,7 @@ import { EditorQueryType, EditorQueryEvaluator } from './editorQueryEvaluator';
 import { JsDebugConfigurationProvider, DebugAdapterExecutableFactory } from './JSDebugger/jsDebugConfigProvider';
 import { JsDebugManager } from './JSDebugger/jsDebugManager';
 import { ClientContext } from './marklogicClient';
+import { MarkLogicUnitTestClient } from './marklogicUnitTestClient';
 import { MlxprsStatus } from './mlxprsStatus';
 import { MlxprsWebViewProvider } from './mlxprsWebViewProvider';
 import { ModuleContentProvider, pickAndShowModule } from './vscModuleContentProvider';
@@ -55,6 +56,7 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 
     const editorQueryEvaluator = new EditorQueryEvaluator(context, provider);
+    const markLogicUnitTestClient = new MarkLogicUnitTestClient(context);
     const sendXQuery = vscode.commands.registerTextEditorCommand(
         'extension.sendXQuery',
         (editor: vscode.TextEditor) => editorQueryEvaluator.editorQuery(EditorQueryType.XQY, editor)
@@ -80,6 +82,13 @@ export function activate(context: vscode.ExtensionContext): void {
         'extension.sendRowsCsvQuery', (editor: vscode.TextEditor) => sendEditorRowsQuery(editor, 'csv'));
     const sendRowsXmlQuery = vscode.commands.registerTextEditorCommand(
         'extension.sendRowsXmlQuery', (editor: vscode.TextEditor) => sendEditorRowsQuery(editor, 'xml'));
+    const runTestModule = vscode.commands.registerTextEditorCommand(
+        'extension.runTestModule',
+        (editor: vscode.TextEditor) => {
+            const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+            markLogicUnitTestClient.runTestModule(cfg, editor);
+        }
+    );
 
 
     const connectJsServer = vscode.commands.registerCommand('extension.connectJsServer', () => {
@@ -121,8 +130,10 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 
     handleUnload(context, [
-        showModule, connectJsServer, disconnectJsServer, connectXqyServer, disconnectXqyServer, sendXQuery,
-        sendJSQuery, sendSqlQuery, sendSparqlQuery, sendRowsJsonQuery, sendRowsCsvQuery, sendRowsXmlQuery
+        connectJsServer, disconnectJsServer, connectXqyServer, disconnectXqyServer,
+        sendXQuery, sendJSQuery, sendSqlQuery, sendSparqlQuery,
+        sendRowsJsonQuery, sendRowsCsvQuery, sendRowsXmlQuery,
+        runTestModule, showModule
     ]);
     handleUnload(context, [
         vscode.languages.registerDocumentFormattingEditProvider(
@@ -199,6 +210,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const mlxprsWebViewProvider = new MlxprsWebViewProvider(context.extensionUri);
     const mlxprsWebView = vscode.window.registerWebviewViewProvider(MlxprsWebViewProvider.viewType, mlxprsWebViewProvider);
     EditorQueryEvaluator.registerMlxprsResultsViewProvider(mlxprsWebViewProvider);
+    MarkLogicUnitTestClient.registerMlxprsResultsViewProvider(mlxprsWebViewProvider);
     context.subscriptions.push(mlxprsWebView);
     handleUnload(context, [mlxprsWebView]);
 }

--- a/client/marklogicClient.ts
+++ b/client/marklogicClient.ts
@@ -385,6 +385,21 @@ export async function filterJsServerByConnectedStatus(
     return filteredChoices;
 }
 
+export function requestMarkLogicUnitTest(
+    dbClientContext: ClientContext, testSuite: string, testFile: string
+): ml.ResultProvider<unknown> {
+    let endpoint = `/v1/resources/marklogic-unit-test?rs:format=xml&rs:func=run&rs:suite=${testSuite}`;
+    if (testFile) {
+        endpoint = `${endpoint}&rs:tests=${testFile}`;
+    }
+    return dbClientContext.databaseClient.internal.sendRequest(
+        endpoint,
+        (requestOptions: ml.RequestOptions) => {
+            requestOptions.method = 'GET';
+        }
+    );
+}
+
 export function newMarklogicManageClient(dbClientContext: ClientContext, managePort: number): ClientContext {
     const manageClientParams: MlClientParameters = JSON.parse(JSON.stringify(dbClientContext.params));
     manageClientParams.port = managePort;

--- a/client/marklogicUnitTestClient.ts
+++ b/client/marklogicUnitTestClient.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import path = require('path');
+import {
+    ExtensionContext, TextEditor, WorkspaceConfiguration
+} from 'vscode';
+
+import { ClientContext, MlClientParameters, requestMarkLogicUnitTest } from './marklogicClient';
+import { buildMlxprsErrorFromError, MlxprsError } from './mlxprsErrorBuilder';
+import { MlxprsErrorReporter } from './mlxprsErrorReporter';
+import { MlxprsWebViewProvider } from './mlxprsWebViewProvider';
+
+export class MarkLogicUnitTestClient {
+    static mlxprsWebViewProvider: MlxprsWebViewProvider = null;
+
+    public static registerMlxprsResultsViewProvider(mlxprsWebViewProvider: MlxprsWebViewProvider) {
+        MarkLogicUnitTestClient.mlxprsWebViewProvider = mlxprsWebViewProvider;
+    }
+
+    private extensionContext: ExtensionContext;
+
+    public constructor(context: ExtensionContext) {
+        this.extensionContext = context;
+    }
+
+    private newMarklogicUnitTestClient(cfg: WorkspaceConfiguration): ClientContext {
+        const configParams: Record<string, unknown> = {
+            host: String(cfg.get('marklogic.host')),
+            user: String(cfg.get('marklogic.username')),
+            pwd: String(cfg.get('marklogic.password')),
+            port: Number(cfg.get('marklogic.unitTestPort')),
+            contentDb: null,
+            modulesDb: null,
+            authType: String(cfg.get('marklogic.authType')).toUpperCase(),
+            ssl: Boolean(cfg.get('marklogic.ssl')),
+            pathToCa: String(cfg.get('marklogic.pathToCa') || ''),
+            rejectUnauthorized: Boolean(cfg.get('marklogic.rejectUnauthorized'))
+        };
+        const newParams = new MlClientParameters(configParams);
+        return new ClientContext(newParams);
+    }
+
+    public async runTestModule(
+        cfg: WorkspaceConfiguration, editor: TextEditor
+    ): Promise<void> {
+        const splitString = `test${path.sep}suites${path.sep}`;
+        const filePath = editor.document.uri.path;
+        const splitLocation = filePath.lastIndexOf(splitString) + splitString.length;
+        if (splitLocation > splitString.length) {
+            const testPath = filePath.substring(splitLocation);
+            const lastSlash = testPath.lastIndexOf('/');
+            const testSuite = testPath.substring(0, lastSlash);
+            const testFile = testPath.substring(lastSlash + 1);
+
+            const dbClientContext: ClientContext = this.newMarklogicUnitTestClient(cfg);
+            requestMarkLogicUnitTest(dbClientContext, testSuite, testFile)
+                .result((testResults: string) => {
+                    const testResultsHtml = MlxprsWebViewProvider.convertXmlResponseToHtml(testResults);
+                    MarkLogicUnitTestClient.mlxprsWebViewProvider.updateViewContent(testResultsHtml);
+                    return null;
+                })
+                .catch(error => {
+                    const mlxprsError: MlxprsError = buildMlxprsErrorFromError(error, `Unable to run the test module: ${error['code']}`);
+                    MlxprsErrorReporter.reportError(mlxprsError);
+                    return null;
+                });
+        } else {
+            const errorMessage = 'Unable to run test; please ensure the file is a marklogic-unit-test module located in a test suite directory';
+            const pathError = new Error(errorMessage);
+            const mlxprsError: MlxprsError = buildMlxprsErrorFromError(pathError, errorMessage);
+            MlxprsErrorReporter.reportError(mlxprsError);
+            return null;
+        }
+        return null;
+    }
+}

--- a/client/mlxprsWebViewProvider.ts
+++ b/client/mlxprsWebViewProvider.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { CancellationToken, SnippetString, Uri, Webview, WebviewView, WebviewViewProvider, WebviewViewResolveContext, window } from 'vscode';
+import { XMLParser, XMLBuilder } from 'fast-xml-parser';
+import {
+    CancellationToken, SnippetString, Uri, Webview, WebviewView,
+    WebviewViewProvider, WebviewViewResolveContext, window
+} from 'vscode';
 
 export class MlxprsWebViewProvider implements WebviewViewProvider {
 
@@ -78,6 +82,25 @@ export class MlxprsWebViewProvider implements WebviewViewProvider {
         ${content}
       </body>
       </html>`;
+    }
+
+    public static convertXmlResponseToHtml(rawXml: string): string {
+        const options = {
+            ignoreAttributes: false,
+            attributeNamePrefix: '@_',
+            format: true
+        };
+        const parser = new XMLParser(options);
+        const jObj = parser.parse(rawXml);
+        const builder = new XMLBuilder(options);
+        const formattedXml = builder.build(jObj);
+
+        const lineCount = (formattedXml.match(/\n/g) || []).length + 1;
+        return `<textarea white-space: pre; rows="${lineCount}" cols="40" style="width: 100%; color: #fff;background: transparent;border:none;">` + formattedXml + '</textarea>';
+    }
+
+    public static convertTextResponseToHtml(text: string): string {
+        return '<pre>' + text + '</pre>';
     }
 
 }

--- a/client/test/integration/marklogicUnitTest.test.ts
+++ b/client/test/integration/marklogicUnitTest.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { XMLParser } from 'fast-xml-parser';
+
+import { ClientContext, requestMarkLogicUnitTest } from '../../marklogicClient';
+import { IntegrationTestHelper } from './markLogicIntegrationTestHelper';
+
+const options = {
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    format: true
+};
+
+suite('Testing MarkLogic-Unit-Test functionality', async () => {
+    const integrationTestHelper: IntegrationTestHelper = globalThis.integrationTestHelper;
+
+    test('When a test is requested that should pass completely', async () => {
+        const mlUnitTestClient: ClientContext = new ClientContext(integrationTestHelper.mlUnitTestClientParameters);
+        await requestMarkLogicUnitTest(mlUnitTestClient, 'SampleJavaScriptTestSuite', 'sample-jstest.sjs')
+            .result((testResults: string) => {
+                const parser = new XMLParser(options);
+                const jObj = parser.parse(testResults);
+                assert.equal(jObj['test:suite']['@_failed'], '0', 'Then there should be 0 failing tests');
+            })
+            .catch(error => {
+                console.debug(error);
+                assert.fail(`Then the call to MarkLogic should succeed (even if the tests fail): ${error.message}`);
+            });
+    }).timeout(5000);
+
+    test('When a test is requested that does not exist', async () => {
+        const mlUnitTestClient: ClientContext = new ClientContext(integrationTestHelper.mlUnitTestClientParameters);
+        await requestMarkLogicUnitTest(mlUnitTestClient, 'SampleJavaScriptTestSuite', 'doesNotExist.sjs')
+            .result((testResults: string) => {
+                const parser = new XMLParser(options);
+                const jObj = parser.parse(testResults);
+                assert.equal(jObj['test:suite']['@_failed'], '1', 'Then there should be 1 failing tests');
+                assert.equal(jObj['test:suite']['@_passed'], '0', 'Then there should be 0 passing tests');
+                assert.equal(jObj['test:suite']['test:test']['test:result']['error:error']['error:code'], 'XDMP-MODNOTFOUND', 'Then the failure should be due to a module not found');
+            })
+            .catch(error => {
+                console.debug(error);
+                assert.fail(`Then the call to MarkLogic should succeed (even if the tests fail): ${error.message}`);
+            });
+    }).timeout(5000);
+
+    test('When a test is requested that should have a failing test', async () => {
+        const mlUnitTestClient: ClientContext = new ClientContext(integrationTestHelper.mlUnitTestClientParameters);
+        await requestMarkLogicUnitTest(mlUnitTestClient, 'SampleJavaScriptTestSuite', 'sample-failing-jstest.sjs')
+            .result((testResults: string) => {
+                const parser = new XMLParser(options);
+                const jObj = parser.parse(testResults);
+                assert.equal(jObj['test:suite']['@_failed'], '1', 'Then there should be 1 failing tests');
+                assert.equal(jObj['test:suite']['@_passed'], '0', 'Then there should be 0 passing tests');
+                assert.equal(jObj['test:suite']['test:test']['test:result']['error:error']['error:message'], 'expected: 0 actual: 2', 'Then the failure should be due to an unexpected value');
+            })
+            .catch(error => {
+                console.debug(error);
+                assert.fail(`Then the call to MarkLogic should succeed (even if the tests fail): ${error.message}`);
+            });
+    }).timeout(5000);
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,15 @@
                 "vscode": "^1.78.0"
             }
         },
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -81,14 +90,14 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-            "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
+            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.2",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -282,9 +291,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -411,9 +420,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.40.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
-            "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.0.tgz",
+            "integrity": "sha512-gsF+c/0XOguWgaOgvFs+xnnRqt9GwgTvIks36WpE6ueeI4KCEHHd8K/CKHqhOqrJKsYH8m27kRzQEvWXAwXUTw==",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -922,9 +931,9 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "node_modules/acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1250,9 +1259,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001506",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-            "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+            "version": "1.0.30001514",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
+            "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1614,9 +1623,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.439",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.439.tgz",
-            "integrity": "sha512-BHpErPSNhb9FB25+OwQP6mCAf3ZXfGbmuvc4LzBNVJwpCcXQJm++LerimocYRG9FRxUVRKZqaB7d0+pImSTPSg=="
+            "version": "1.4.454",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.454.tgz",
+            "integrity": "sha512-pmf1rbAStw8UEQ0sr2cdJtWl48ZMuPD9Sto8HVQOq9vx9j2WgDEN6lYoaqFvqEHYOmGA9oRGn7LqWI9ta0YugQ=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1645,9 +1654,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.9.0.tgz",
-            "integrity": "sha512-RODB4txU+xImYDemN5DqaKC0CHk05XSVkOX4pq0hK26Qx+1LChkuOyUDlGEjYb3ACr0n9qBhFjg37hQuJvpkRQ==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
+            "integrity": "sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -1787,12 +1796,12 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
+            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.4.1"
             },
@@ -1895,15 +1904,15 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-fifo": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.2.0.tgz",
-            "integrity": "sha512-NcvQXt7Cky1cNau15FWy64IjuO8X0JijhTBBrJj1YlxlDfRkJXNaK9RFUjwpfDPzMdv7wB38jr53l9tkNLxnWg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
+            "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw==",
             "optional": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -2887,9 +2896,9 @@
             }
         },
         "node_modules/minipass": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.1.tgz",
+            "integrity": "sha512-NQ8MCKimInjVlaIqx51RKJJB7mINVkLTJbsZKmto4UAAOC/CWXES8PGaOgoBZyqoUsUA/U3DToGK7GJkkHbjJw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3084,9 +3093,9 @@
             "optional": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-            "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -3114,17 +3123,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -3221,13 +3230,13 @@
             "dev": true
         },
         "node_modules/path-scurry": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-            "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.2"
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3237,9 +3246,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-            "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+            "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
@@ -3628,16 +3637,16 @@
             }
         },
         "node_modules/rimraf/node_modules/glob": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.0.tgz",
-            "integrity": "sha512-AQ1/SB9HH0yCx1jXAT4vmCbTOPe5RQ+kCurjbel5xSCGhebumUv+GJZfa1rEqor3XIViqwSEmlkZCQD43RWrBg==",
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+            "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
             "dev": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^2.0.3",
                 "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2",
-                "path-scurry": "^1.7.0"
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
             },
             "bin": {
                 "glob": "dist/cjs/src/bin.js"
@@ -3650,9 +3659,9 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-            "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -3723,9 +3732,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4084,9 +4093,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
-            "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+            "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -4273,9 +4282,9 @@
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
         },
         "node_modules/typescript": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-            "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -4537,15 +4546,6 @@
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true
         },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/workerpool": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
@@ -4699,6 +4699,12 @@
         }
     },
     "dependencies": {
+        "@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true
+        },
         "@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -4721,14 +4727,14 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-            "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
+            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.2",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -4860,9 +4866,9 @@
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
         },
         "@jridgewell/source-map": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
             "requires": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -4973,9 +4979,9 @@
             "dev": true
         },
         "@types/eslint": {
-            "version": "8.40.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
-            "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.0.tgz",
+            "integrity": "sha512-gsF+c/0XOguWgaOgvFs+xnnRqt9GwgTvIks36WpE6ueeI4KCEHHd8K/CKHqhOqrJKsYH8m27kRzQEvWXAwXUTw==",
             "requires": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -5363,9 +5369,9 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ=="
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
         },
         "acorn-import-assertions": {
             "version": "1.9.0",
@@ -5584,9 +5590,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001506",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-            "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw=="
+            "version": "1.0.30001514",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
+            "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ=="
         },
         "chalk": {
             "version": "4.1.2",
@@ -5855,9 +5861,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.439",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.439.tgz",
-            "integrity": "sha512-BHpErPSNhb9FB25+OwQP6mCAf3ZXfGbmuvc4LzBNVJwpCcXQJm++LerimocYRG9FRxUVRKZqaB7d0+pImSTPSg=="
+            "version": "1.4.454",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.454.tgz",
+            "integrity": "sha512-pmf1rbAStw8UEQ0sr2cdJtWl48ZMuPD9Sto8HVQOq9vx9j2WgDEN6lYoaqFvqEHYOmGA9oRGn7LqWI9ta0YugQ=="
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -5883,9 +5889,9 @@
             }
         },
         "envinfo": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.9.0.tgz",
-            "integrity": "sha512-RODB4txU+xImYDemN5DqaKC0CHk05XSVkOX4pq0hK26Qx+1LChkuOyUDlGEjYb3ACr0n9qBhFjg37hQuJvpkRQ==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
+            "integrity": "sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
             "dev": true
         },
         "es-module-lexer": {
@@ -5985,12 +5991,12 @@
             "dev": true
         },
         "espree": {
-            "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
+            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
             "dev": true,
             "requires": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.4.1"
             }
@@ -6060,15 +6066,15 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-fifo": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.2.0.tgz",
-            "integrity": "sha512-NcvQXt7Cky1cNau15FWy64IjuO8X0JijhTBBrJj1YlxlDfRkJXNaK9RFUjwpfDPzMdv7wB38jr53l9tkNLxnWg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
+            "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw==",
             "optional": true
         },
         "fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -6781,9 +6787,9 @@
             "optional": true
         },
         "minipass": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.1.tgz",
+            "integrity": "sha512-NQ8MCKimInjVlaIqx51RKJJB7mINVkLTJbsZKmto4UAAOC/CWXES8PGaOgoBZyqoUsUA/U3DToGK7GJkkHbjJw==",
             "dev": true
         },
         "mkdirp-classic": {
@@ -6947,9 +6953,9 @@
             "optional": true
         },
         "node-releases": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-            "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -6971,17 +6977,17 @@
             }
         },
         "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "requires": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             }
         },
         "p-limit": {
@@ -7048,19 +7054,19 @@
             "dev": true
         },
         "path-scurry": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-            "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "dev": true,
             "requires": {
-                "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.2"
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "dependencies": {
                 "lru-cache": {
-                    "version": "9.1.2",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-                    "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+                    "version": "10.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+                    "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
                     "dev": true
                 }
             }
@@ -7351,22 +7357,22 @@
                     }
                 },
                 "glob": {
-                    "version": "10.3.0",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.0.tgz",
-                    "integrity": "sha512-AQ1/SB9HH0yCx1jXAT4vmCbTOPe5RQ+kCurjbel5xSCGhebumUv+GJZfa1rEqor3XIViqwSEmlkZCQD43RWrBg==",
+                    "version": "10.3.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+                    "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
                     "dev": true,
                     "requires": {
                         "foreground-child": "^3.1.0",
                         "jackspeak": "^2.0.3",
                         "minimatch": "^9.0.1",
-                        "minipass": "^5.0.0 || ^6.0.2",
-                        "path-scurry": "^1.7.0"
+                        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                        "path-scurry": "^1.10.1"
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-                    "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
@@ -7409,9 +7415,9 @@
             }
         },
         "semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -7671,9 +7677,9 @@
             }
         },
         "terser": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
-            "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+            "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
             "requires": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -7803,9 +7809,9 @@
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
         },
         "typescript": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-            "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "peer": true
         },
         "update-browserslist-db": {
@@ -7976,12 +7982,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-            "dev": true
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
         "workerpool": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "onCommand:extension.sendSql",
         "onCommand:extension.sendSparqlQuery",
         "onCommand:extension.showModule",
+        "onCommand:extension.runTestModule",
         "onDebug",
         "onLanguage:xquery-ml",
         "onLanguage:javascript",
@@ -101,6 +102,10 @@
             {
                 "command": "extension.showModule",
                 "title": "MarkLogic: Show module"
+            },
+            {
+                "command": "extension.runTestModule",
+                "title": "MarkLogic: Run marklogic-unit-test module"
             }
         ],
         "breakpoints": [
@@ -326,20 +331,26 @@
                         "default": 8000,
                         "description": "The port of a REST API app server to connect to"
                     },
-                    "marklogic.documentsDb": {
+                    "marklogic.testPort": {
                         "order": 4,
+                        "type": "integer",
+                        "default": 8004,
+                        "description": "Optional port for a REST API server that supports running marklogic-unit-test modules"
+                    },
+                    "marklogic.documentsDb": {
+                        "order": 5,
                         "type": "string",
                         "default": "",
                         "description": "database against which to evaluate queries; required for debugging a local script"
                     },
                     "marklogic.modulesDb": {
-                        "order": 5,
+                        "order": 6,
                         "type": "string",
                         "default": "",
                         "description": "modules database used in queries; default modules database for app server will be used if left unspecified"
                     },
                     "marklogic.modulesRoot": {
-                        "order": 6,
+                        "order": 7,
                         "type": "string",
                         "default": "/",
                         "description": "modules root if using filesystem"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -56,9 +56,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.3.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-            "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
+            "version": "20.4.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+            "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
             "dev": true
         },
         "node_modules/@types/vscode": {
@@ -1105,9 +1105,9 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -1414,9 +1414,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.3.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-            "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
+            "version": "20.4.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+            "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
             "dev": true
         },
         "@types/vscode": {
@@ -2198,9 +2198,9 @@
             "dev": true
         },
         "semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"

--- a/test-app/.vscode/settings.json
+++ b/test-app/.vscode/settings.json
@@ -6,5 +6,6 @@
     "marklogic.modulesDb": "mlxprs-test-modules",
     "marklogic.rejectUnauthorized": false,
     "marklogic.ssl": false,
-    "marklogic.managePort": 8002
+    "marklogic.managePort": 8002,
+    "marklogic.unitTestPort": 8054
 }

--- a/test-app/src/test/ml-modules/root/test/suites/SampleJavaScriptTestSuite/sample-failing-jstest.sjs
+++ b/test-app/src/test/ml-modules/root/test/suites/SampleJavaScriptTestSuite/sample-failing-jstest.sjs
@@ -1,0 +1,12 @@
+const test = require('/test/test-helper.xqy');
+const f = require('/lib/factorial.sjs');
+
+let assertions = [];
+
+assertions.push(
+    test.assertEqual(1, f.factorial(1)),
+    test.assertEqual(0, f.factorial(2)),
+    test.assertEqual(6, f.factorial(3))
+);
+
+assertions;


### PR DESCRIPTION
Adds the feature to run a single ML Unit Test - based on the current editor tab.

Added a new configure option to specify the port that the unit tests are running on.

Update README - including unrelated tweaks.

Moved a couple helper functions that are only used for the MLXPRS webview to the webview provider.

Includes a little refactoring of MarkLogic client generation in the TestHelper file.