### PR TITLE
DEVEXP-500: Move mlxprs to marklogic github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.7.0](https://github.com/marklogic-community/mlxprs/releases/tag/v3.7.0)
+## [3.7.0](https://github.com/marklogic/mlxprs/releases/tag/v3.7.0)
 
 - [#DEV-261](https://project.marklogic.com/jira/browse/DEVEXP-261) Submit an Optic DSL Query to /v1/rows and get back JSON
 - [#DEV-262](https://project.marklogic.com/jira/browse/DEVEXP-262) Submit Optic Query and get back XML or CSV
@@ -9,17 +9,17 @@
 - [#DEV-364](https://project.marklogic.com/jira/browse/DEVEXP-364) Permit attaching to a remote request even if the current editor tab is not source code
 
 
-## [3.6.2](https://github.com/marklogic-community/mlxprs/releases/tag/v3.6.2)
+## [3.6.2](https://github.com/marklogic/mlxprs/releases/tag/v3.6.2)
 
 - Fixed the icon used in the Visual Studio Marketplace 
 
-## [3.6.0](https://github.com/marklogic-community/mlxprs/releases/tag/v3.6.0)
+## [3.6.0](https://github.com/marklogic/mlxprs/releases/tag/v3.6.0)
 
-- [#116](https://github.com/marklogic-community/mlxprs/issues/116) Updated dependencies and fixed all known security vulnerabilities
-- [#119](https://github.com/marklogic-community/mlxprs/issues/119) Added SJS binding to JavaScript language
-- [#97](https://github.com/marklogic-community/mlxprs/issues/97) Added a configuration option for the MarkLogic Manage app server port (used for the SJS debug server port)
-- [#117](https://github.com/marklogic-community/mlxprs/issues/117) Fixed a bug with the first attempt to eval a JavaScript tab
-- [#109](https://github.com/marklogic-community/mlxprs/issues/109) Prevent the database param from being used in REST calls when the database setting is empty
+- [#116](https://github.com/marklogic/mlxprs/issues/116) Updated dependencies and fixed all known security vulnerabilities
+- [#119](https://github.com/marklogic/mlxprs/issues/119) Added SJS binding to JavaScript language
+- [#97](https://github.com/marklogic/mlxprs/issues/97) Added a configuration option for the MarkLogic Manage app server port (used for the SJS debug server port)
+- [#117](https://github.com/marklogic/mlxprs/issues/117) Fixed a bug with the first attempt to eval a JavaScript tab
+- [#109](https://github.com/marklogic/mlxprs/issues/109) Prevent the database param from being used in REST calls when the database setting is empty
 
 
 ## [3.5.1](https://github.com/mikrovvelle/mlxprs/tree/v3.5.1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to mlxprs
 
-The MarkLogic extension for Visual Studio Code is an open-source project developed and maintained by the community. You can help by identifying bugs, requesting features you’d like to see, or even submitting code.
+The MarkLogic extension for Visual Studio Code is an open-source project developed and maintained by the MarkLogic and the community. You can help by identifying bugs, requesting features you’d like to see, or even submitting code.
 
 _This project and its code and functionality are not representative of MarkLogic Server and are not supported by MarkLogic._
 
 ## Found a bug or issue?
 
-If you find a problem, or want to request something that’s lacking, please [file an issue](https://github.com/marklogic-community/mlxprs/issues/new). Make sure to specify which version of the extension you’re using as well as the version of MarkLogic you’re working against.
+If you find a problem, or want to request something that’s lacking, please [file an issue](https://github.com/marklogic/mlxprs/issues/new). Make sure to specify which version of the extension you’re using as well as the version of MarkLogic you’re working against.
 
 Even better, you can submit a Pull Request with a fix for the issue you filed.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "Snippets",
         "Other"
     ],
-    "repository": "https://github.com/marklogic-community/mlxprs",
+    "repository": "https://github.com/marklogic/mlxprs",
     "license": "(Apache-2.0 AND MIT)",
     "activationEvents": [
         "onCommand:extension.getQuery",


### PR DESCRIPTION
Updating URLs to remove "-community"