### PR TITLE
Debug Status view now uses basePath

### DIFF
--- a/client/JSDebugger/mlRuntime.ts
+++ b/client/JSDebugger/mlRuntime.ts
@@ -86,7 +86,7 @@ export class MLRuntime extends EventEmitter {
     private _mlModuleGetter: ModuleContentGetter;
     private managePort = null;
     // TODO - manageBasePath
-    private manageBasePath = null;
+    private manageBasePath = '';
 
     public getHostString(): string {
         return `${this.dbClientContext.params.host}:${this.dbClientContext.params.port}`;

--- a/client/marklogicDebugStatus.ts
+++ b/client/marklogicDebugStatus.ts
@@ -11,6 +11,7 @@ export class MarkLogicDebugStatusTreeDataProvider implements vscode.TreeDataProv
 
     private dbClientContext: ClientContext;
     private managePort: number;
+    private manageBasePath: string;
     private: ClientContext;
 
     constructor() {
@@ -27,6 +28,7 @@ export class MarkLogicDebugStatusTreeDataProvider implements vscode.TreeDataProv
     private configure() {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
         this.managePort = Number(cfg.get('marklogic.managePort')) || ClientContext.DEFAULT_MANAGE_PORT;
+        this.manageBasePath = String(cfg.get('marklogic.manageBasePath')) || '';
         this.dbClientContext = new ClientContext(newClientParams(cfg));
     }
 
@@ -70,7 +72,7 @@ export class MarkLogicDebugStatusTreeDataProvider implements vscode.TreeDataProv
 
     private async buildDebugAppServerEntries(): Promise<MarkLogicDebugStatus[]> {
         const connectedServerTreeElementList: MarkLogicDebugStatus[] = [];
-        return this.dbClientContext.getConnectedServers(null, this.managePort, null)
+        return this.dbClientContext.getConnectedServers(null, this.managePort, this.manageBasePath, null)
             .then((connectedServers) => {
                 if (connectedServers.length > 0) {
                     connectedServers.forEach(serverName => {

--- a/client/mlxprsStatus.ts
+++ b/client/mlxprsStatus.ts
@@ -26,10 +26,12 @@ export class MlxprsStatus {
     private command: vscode.Disposable;
     private connectedServers = null;
     private managePort: number;
+    private manageBasePath: string;
 
     constructor(context: vscode.ExtensionContext) {
         const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
         this.managePort = Number(cfg.get('marklogic.managePort')) || ClientContext.DEFAULT_MANAGE_PORT;
+        this.manageBasePath = String(cfg.get('marklogic.manageBasePath')) || '';
         this.dbClientContext = getDbClientWithoutOverrides(cfg, context.globalState);
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
         this.command = vscode.commands.registerCommand(this.commandId, () => {
@@ -47,7 +49,7 @@ export class MlxprsStatus {
     }
 
     requestUpdate(): void {
-        this.dbClientContext.getConnectedServers(this, this.managePort, this.updateStatusBarItem);
+        this.dbClientContext.getConnectedServers(this, this.managePort, this.manageBasePath, this.updateStatusBarItem);
     }
 
     updateStatusBarItem(connectedServers: string[]): void {

--- a/client/test/integration/markLogicIntegrationTestHelper.ts
+++ b/client/test/integration/markLogicIntegrationTestHelper.ts
@@ -50,10 +50,11 @@ export class IntegrationTestHelper {
 
     private hostname = String(process.env.ML_HOST || 'localhost');
     private port = Number(process.env.ML_PORT || this.configuredServerPort);
-    readonly restBasePath = String(process.env.ML_RESTBASEPATH);
+    readonly restBasePath = process.env.ML_RESTBASEPATH ? String(process.env.ML_RESTBASEPATH) : '';
     readonly managePort = Number(process.env.ML_MANAGEPORT) || 8059;
-    readonly manageBasePath = String(process.env.ML_MANAGEPATH) || '';
+    readonly manageBasePath = process.env.ML_MANAGEBASEPATH ? String(process.env.ML_MANAGEBASEPATH) : '';
     readonly unitTestPort = Number(process.env.ML_UNITTESTPORT || '8054');
+    readonly testBasePath = process.env.ML_TESTBASEPATH ? String(process.env.ML_TESTBASEPATH) : '';
     private username = String(process.env.ML_USERNAME || 'admin');
     private password = String(process.env.ML_PASSWORD || 'admin');
     private modulesDB = String(process.env.ML_MODULESDB || this.modulesDatabase);
@@ -321,9 +322,6 @@ export class IntegrationTestHelper {
 
     private newClientWithDefaultsAndOverrides(overrides: object = {}): ClientContext {
         const newParams = new MlClientParameters({ ...this.clientDefaults, ...overrides });
-        if (newParams.restBasePath === 'undefined') {
-            newParams.restBasePath = '';
-        }
         return new ClientContext(newParams);
     }
 

--- a/client/test/integration/marklogicClient.test.ts
+++ b/client/test/integration/marklogicClient.test.ts
@@ -28,22 +28,23 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
     const integrationTestHelper: IntegrationTestHelper = globalThis.integrationTestHelper;
     const dbClientContext: ClientContext = integrationTestHelper.mlClient;
     const managePort = integrationTestHelper.managePort;
+    const manageBasePath = integrationTestHelper.manageBasePath;
     const attachServerName: string = integrationTestHelper.attachServerName;
 
     test('When there are no "connected" app-servers initially', async () => {
-        const disconnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, 'false');
+        const disconnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, manageBasePath, 'false');
         assert.ok(disconnectedAppServers.length,
             'this will return an unpredictable number, but in any case it should be greater than 0');
-        const connectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, 'true');
+        const connectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, manageBasePath, 'true');
         assert.equal(connectedAppServers.length, 0, 'no app servers should be returned for this list');
 
         await JsDebugManager.connectToNamedJsDebugServer(attachServerName);
         globalThis.integrationTestHelper.attachedToServer = true;
 
-        const updatedDisconnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, 'false');
+        const updatedDisconnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, manageBasePath, 'false');
         assert.equal(updatedDisconnectedAppServers.length + 1, disconnectedAppServers.length,
             'This will return 1 fewer app servers than the previous number of disconnected app servers');
-        const updatedConnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, 'true');
+        const updatedConnectedAppServers = await getFilteredListOfJsAppServers(dbClientContext, managePort, manageBasePath, 'true');
         assert.equal(updatedConnectedAppServers.length, 1, 'This will return the single app server that was connected to');
     }).timeout(5000);
 


### PR DESCRIPTION
Additionally, this has the ripple effect of requiring the mlxprs status bar component to use basePath as well.
Also, required updated some integration tests.