### PR TITLE
Can now debug behind a proxy server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,13 @@ command will start the reverse proxy server in blocking mode listening on port 8
 will then forward requests to port 8020 based on the custom mappings.
 
 ```
-./gradlew runBlockingReverseProxyServer -PrpsCustomMappings=/mlxprs/manage,8059,/mlxprs/rest,8055,/mlxprs/test,8054
+./gradlew runBlockingReverseProxyServer
+```
+Node Client Test-App Reverse Proxy Mappings
+```
+"/mlxprs/manage" => port 8059
+"/mlxprs/rest"   => port 8055
+"/mlxprs/test"   => port 8054
 ```
 
 Once the reverse proxy server is running, change the MLXPRS settings for your workspace

--- a/client/JSDebugger/jsDebugConfigProvider.ts
+++ b/client/JSDebugger/jsDebugConfigProvider.ts
@@ -78,6 +78,7 @@ export class JsDebugConfigurationProvider implements vscode.DebugConfigurationPr
         config.username = String(wcfg.get('marklogic.username'));
         config.password = String(wcfg.get('marklogic.password'));
         config.managePort = Number(wcfg.get('marklogic.managePort'));
+        config.manageBasePath = String(wcfg.get('marklogic.manageBasePath'));
         config.database = String(wcfg.get('marklogic.documentsDb'));
         config.modules = String(wcfg.get('marklogic.modulesDb'));
         config.mlModulesRoot = String(wcfg.get('marklogic.modulesRoot'));

--- a/client/JSDebugger/jsDebugManager.ts
+++ b/client/JSDebugger/jsDebugManager.ts
@@ -357,6 +357,7 @@ function newManageConfig() {
     return new MlClientParameters({
         host: cfg.get('host'),
         port: cfg.get('managePort'),
+        restBasePath: cfg.get('manageBasePath'),
         user: cfg.get('username'),
         pwd: cfg.get('password'),
         authType: cfg.get('authType'),

--- a/client/JSDebugger/mlRuntime.ts
+++ b/client/JSDebugger/mlRuntime.ts
@@ -118,6 +118,7 @@ export class MLRuntime extends EventEmitter {
         this._password = args.password;
         this._dbgPort = args.managePort;
         this.managePort = args.managePort;
+        this.manageBasePath = args.manageBasePath;
         this._ssl = args.ssl;
         this._scheme = this._ssl ? 'https' : 'http';
         this._rejectUnauthorized = args.rejectUnauthorized;
@@ -129,6 +130,7 @@ export class MLRuntime extends EventEmitter {
             new MlClientParameters({
                 host: this._hostName,
                 port: this._dbgPort,
+                restBasePath: this.manageBasePath,
                 user: this._username,
                 pwd: this._password,
                 contentDb: args.database,

--- a/client/XQDebugger/xqyDebugConfigProvider.ts
+++ b/client/XQDebugger/xqyDebugConfigProvider.ts
@@ -55,7 +55,9 @@ export class XqyDebugConfigurationProvider implements DebugConfigurationProvider
         const clientParams: MlClientParameters = new MlClientParameters({
             host: String(ConfigurationManager.getHost()),
             port: Number(ConfigurationManager.getPort()),
+            restBasePath: String(ConfigurationManager.getRestBasePath()),
             managePort: Number(ConfigurationManager.getManagePort()),
+            manageBasePath: String(ConfigurationManager.getManageBasePath()),
             user: String(ConfigurationManager.getUsername()),
             pwd: String(ConfigurationManager.getPassword()),
             contentDb: String(ConfigurationManager.getDocumentsDb()),

--- a/client/configurationManager.ts
+++ b/client/configurationManager.ts
@@ -19,7 +19,9 @@ import * as vscode from 'vscode';
 export interface MarklogicConfigurationSettings {
     host?: string;
     port?: string;
+    restBasePath?: string;
     managePort?: string;
+    manageBasePath?: string;
     username?: string;
     password?: string;
     documentsDb?: string;
@@ -59,8 +61,16 @@ export class ConfigurationManager {
         return ConfigurationManager.getConfigValue('port') as string;
     }
 
+    static getRestBasePath(): string {
+        return ConfigurationManager.getConfigValue('restBasePath') as string;
+    }
+
     static getManagePort(): string {
         return ConfigurationManager.getConfigValue('managePort') as string;
+    }
+
+    static getManageBasePath(): string {
+        return ConfigurationManager.getConfigValue('manageBasePath') as string;
     }
 
     static getUsername(): string {

--- a/client/marklogicClient.ts
+++ b/client/marklogicClient.ts
@@ -519,6 +519,7 @@ export function newClientParams(cfg: WorkspaceConfiguration, overrides: object =
         user: String(cfg.get('marklogic.username')),
         pwd: String(cfg.get('marklogic.password')),
         port: Number(cfg.get('marklogic.port')),
+        restBasePath: String(cfg.get('marklogic.restBasePath')) || '',
         managePort: Number(cfg.get('marklogic.managePort')),
         manageBasePath: String(cfg.get('marklogic.manageBasePath')) || '',
         adminPort: Number(cfg.get('marklogic.adminPort')),

--- a/test-app/.vscode/settings.json
+++ b/test-app/.vscode/settings.json
@@ -2,7 +2,7 @@
     "marklogic.host": "localhost",
     "marklogic.ssl": false,
     "marklogic.authType": "BASIC",
-    "marklogic.port": 8055,
+    "marklogic.port": 8020,
     "marklogic.restBasePath": "/mlxprs/rest",
     "marklogic.managePort": 8020,
     "marklogic.manageBasePath": "/mlxprs/manage",


### PR DESCRIPTION
Also working:
Connect/Disconnect to JS & XQY servers.
Eval JS, XQY, GraphQl, Optic, Optic DSL, SPARQL, and SQL.
Validate TDE template.
Extract data via TDE.
Show module from database.