### PR TITLE
First step towards replacing MlClientParameters

### DIFF
--- a/client/XQDebugger/xqyDebugConfigProvider.ts
+++ b/client/XQDebugger/xqyDebugConfigProvider.ts
@@ -23,12 +23,13 @@ import {
 
 import { MlxprsErrorReporter } from '../mlxprsErrorReporter';
 import { MlClientParameters } from '../marklogicClient';
+import { buildClientFactoryFromConfigurationManager } from '../clientFactory';
 import { MlxprsError } from '../mlxprsErrorBuilder';
 import { XqyDebugManager, DebugStatusQueryResponse } from './xqyDebugManager';
-import { ConfigurationManager } from '../configurationManager';
 
-
+/* eslint-disable @typescript-eslint/no-unused-vars */
 export class XqyDebugConfiguration implements DebugConfiguration {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any
     type: string;
     name: string;
@@ -50,23 +51,13 @@ const placeholder: QuickPickOptions = {
 
 export class XqyDebugConfigurationProvider implements DebugConfigurationProvider {
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    private async resolveRemainingDebugConfiguration(folder: WorkspaceFolder | undefined, config: XqyDebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration> {
-        const clientParams: MlClientParameters = new MlClientParameters({
-            host: String(ConfigurationManager.getHost()),
-            port: Number(ConfigurationManager.getPort()),
-            restBasePath: String(ConfigurationManager.getRestBasePath()),
-            managePort: Number(ConfigurationManager.getManagePort()),
-            manageBasePath: String(ConfigurationManager.getManageBasePath()),
-            user: String(ConfigurationManager.getUsername()),
-            pwd: String(ConfigurationManager.getPassword()),
-            contentDb: String(ConfigurationManager.getDocumentsDb()),
-            modulesDb: String(ConfigurationManager.getModulesDb()),
-            authType: String(ConfigurationManager.getAuthType()),
-            ssl: Boolean(ConfigurationManager.getSsl()),
-            pathToCa: String(ConfigurationManager.getPathToCa() || ''),
-            rejectUnauthorized: Boolean(ConfigurationManager.getRejectUnauthorized())
-        });
+    private async resolveRemainingDebugConfiguration(
+        folder: WorkspaceFolder | undefined,
+        config: XqyDebugConfiguration,
+        token?: CancellationToken
+    ): Promise<DebugConfiguration> {
+        const clientParams: MlClientParameters =
+            buildClientFactoryFromConfigurationManager().toMlClientParameters();
         config.clientParams = clientParams;
 
         if (clientParams.pathToCa) {
@@ -113,8 +104,8 @@ export class XqyDebugConfigurationProvider implements DebugConfigurationProvider
     }
 
     /**
-     * @override
-     */
+ * @override
+ */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: XqyDebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
         if (!config.type && !config.request && !config.name) {

--- a/client/clientFactory.ts
+++ b/client/clientFactory.ts
@@ -1,0 +1,208 @@
+import * as ml from 'marklogic';
+
+import { ClientContext, MlClientParameters } from './marklogicClient';
+
+// This class should NOT use the WorkspaceConfiguration (WC) class imported below.
+// The debuggers don't have access to the vscode namespace, including WC.
+// So if WC is used in the class, the debuggers won't be able to use this class.
+// Note that this also precludes the use of ConfigurationManager in the class.
+export class ClientFactory implements ml.ConnectionParams {
+    host: string;
+    port: number;
+    basePath: string;
+    user: string;
+    password: string;
+    database: string;
+    authType: string;
+    ssl: boolean;
+    ca: string;
+    rejectUnauthorized: boolean;
+    // Additional fields not included in ml.ConnectionParams
+    pathToCa: string;
+    modulesDb: string;
+    managePort: number;
+    adminPort: number;
+    testPort: number;
+    manageBasePath: string;
+    adminBasePath: string;
+    restBasePath: string;
+    testBasePath: string;
+
+    constructor(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        rawParams: Record<string, any>
+    ) {
+        this.host = rawParams.host;
+        this.port = Number(rawParams.port);
+        this.basePath = rawParams.basePath || '';
+        this.managePort = Number(rawParams.managePort);
+        this.manageBasePath = rawParams.manageBasePath || '';
+        this.testPort = Number(rawParams.testPort);
+        this.testBasePath = rawParams.testBasePath || '';
+        this.adminPort = Number(rawParams.adminPort);
+        this.adminBasePath = rawParams.adminBasePath || '';
+        this.user = rawParams.user;
+        this.password = rawParams.password;
+        // contentDb is required for backward compatability
+        this.database = rawParams.contentDb || rawParams.documentsDb || '';
+        this.modulesDb = rawParams.modulesDb || '';
+        this.authType = rawParams.authType;
+        this.ssl = Boolean(rawParams.ssl);
+        this.pathToCa = rawParams.pathToCa || '';
+        this.rejectUnauthorized = Boolean(rawParams.rejectUnauthorized);
+
+        // This check was previously done in the MarklogicClient constructor, but doing
+        // so causes the sameAs function in this class to not behave properly
+        if (this.authType !== 'DIGEST' && this.authType !== 'BASIC') {
+            this.authType = 'DIGEST';
+        }
+    }
+
+    toMlClientParameters(): MlClientParameters {
+        return new MlClientParameters({
+            host: this.host,
+            port: this.port,
+            basePath: this.basePath,
+            user: this.user,
+            pwd: this.password,
+            contentDb: this.database,
+            modulesDb: this.modulesDb,
+            authType: this.authType,
+            ssl: this.ssl,
+            pathToCa: this.pathToCa,
+            rejectUnauthorized: this.rejectUnauthorized,
+        });
+    }
+
+    newMarklogicRestClient(
+        overrides: object = {}
+    ): ClientContext {
+        const restClientConnectionParams: ClientFactory =
+            this.newRestClientParams(overrides);
+        return new ClientContext(restClientConnectionParams.toMlClientParameters());
+    }
+
+    newMarklogicManageClient(
+        overrides: object = {}
+    ): ClientContext {
+        const manageClientConnectionParams: ClientFactory =
+            this.newManageClientParams(overrides);
+        return new ClientContext(manageClientConnectionParams.toMlClientParameters());
+    }
+
+    newMarklogicTestClient(
+        overrides: object = {}
+    ): ClientContext {
+        const testClientConnectionParams: ClientFactory =
+            this.newTestClientParams(overrides);
+        return new ClientContext(testClientConnectionParams.toMlClientParameters());
+    }
+
+    newRestClientParams(
+        overrides: object = {}
+    ): ClientFactory {
+        const configParams: Record<string, unknown> = {
+            host: this.host,
+            user: this.user,
+            password: this.password,
+            port: this.port,
+            basePath: this.restBasePath,
+            database: this.database,
+            modulesDb: this.modulesDb,
+            authType: this.authType.toUpperCase(),
+            ssl: this.ssl,
+            pathToCa: this.pathToCa || '',
+            rejectUnauthorized: this.rejectUnauthorized
+        };
+        return new ClientFactory({ ...configParams, ...overrides });
+    }
+
+    newManageClientParams(
+        overrides: object = {}
+    ): ClientFactory {
+        const configParams: Record<string, unknown> = {
+            host: this.host,
+            user: this.user,
+            password: this.password,
+            port: this.managePort,
+            basePath: this.manageBasePath,
+            database: null,
+            modulesDb: null,
+            authType: this.authType.toUpperCase(),
+            ssl: this.ssl,
+            pathToCa: this.pathToCa || '',
+            rejectUnauthorized: this.rejectUnauthorized
+        };
+        return new ClientFactory({ ...configParams, ...overrides });
+    }
+
+    newTestClientParams(
+        overrides: object = {}
+    ): ClientFactory {
+        const configParams: Record<string, unknown> = {
+            host: this.host,
+            user: this.user,
+            password: this.password,
+            port: this.testPort,
+            basePath: this.testBasePath,
+            database: null,
+            modulesDb: null,
+            authType: this.authType.toUpperCase(),
+            ssl: this.ssl,
+            pathToCa: this.pathToCa || '',
+            rejectUnauthorized: this.rejectUnauthorized
+        };
+        return new ClientFactory({ ...configParams, ...overrides });
+    }
+}
+
+import { WorkspaceConfiguration } from 'vscode';
+export function buildClientFactoryFromWorkspaceConfig(
+    cfg: WorkspaceConfiguration,
+    overrides: object = {}
+): ClientFactory {
+    const configParams: Record<string, unknown> = {
+        host: String(cfg.get('marklogic.host')),
+        user: String(cfg.get('marklogic.username')),
+        password: String(cfg.get('marklogic.password')),
+        port: Number(cfg.get('marklogic.port')),
+        restBasePath: String(cfg.get('marklogic.restBasePath')) || '',
+        managePort: Number(cfg.get('marklogic.managePort')),
+        manageBasePath: String(cfg.get('marklogic.manageBasePath')) || '',
+        testPort: Number(cfg.get('marklogic.testPort')),
+        testBasePath: String(cfg.get('marklogic.testBasePath')) || '',
+        adminPort: Number(cfg.get('marklogic.adminPort')),
+        adminBasePath: String(cfg.get('marklogic.adminBasePath')) || '',
+        contentDb: String(cfg.get('marklogic.documentsDb')),
+        modulesDb: String(cfg.get('marklogic.modulesDb')),
+        authType: String(cfg.get('marklogic.authType')).toUpperCase(),
+        ssl: Boolean(cfg.get('marklogic.ssl')),
+        pathToCa: String(cfg.get('marklogic.pathToCa') || ''),
+        rejectUnauthorized: Boolean(cfg.get('marklogic.rejectUnauthorized'))
+    };
+    return new ClientFactory({ ...configParams, ...overrides });
+}
+
+import { ConfigurationManager } from './configurationManager';
+export function buildClientFactoryFromConfigurationManager(): ClientFactory {
+    const configParams: Record<string, unknown> = {
+        host: ConfigurationManager.getHost(),
+        user: ConfigurationManager.getUsername(),
+        password: ConfigurationManager.getPassword(),
+        port: ConfigurationManager.getPort(),
+        restBasePath: ConfigurationManager.getRestBasePath(),
+        managePort: ConfigurationManager.getManagePort(),
+        manageBasePath: ConfigurationManager.getManageBasePath(),
+        testPort: ConfigurationManager.getTestPort(),
+        testBasePath: ConfigurationManager.getTestBasePath(),
+        adminPort: ConfigurationManager.getAdminPort(),
+        adminBasePath: ConfigurationManager.getAdminBasePath(),
+        contentDb: ConfigurationManager.getDocumentsDb(),
+        modulesDb: ConfigurationManager.getModulesDb(),
+        authType: ConfigurationManager.getAuthType(),
+        ssl: ConfigurationManager.getSsl(),
+        pathToCa: ConfigurationManager.getPathToCa() || '',
+        rejectUnauthorized: ConfigurationManager.getRejectUnauthorized()
+    };
+    return new ClientFactory(configParams);
+}

--- a/client/configurationManager.ts
+++ b/client/configurationManager.ts
@@ -22,6 +22,10 @@ export interface MarklogicConfigurationSettings {
     restBasePath?: string;
     managePort?: string;
     manageBasePath?: string;
+    testPort?: string;
+    testBasePath?: string;
+    adminPort?: string;
+    adminBasePath?: string;
     username?: string;
     password?: string;
     documentsDb?: string;
@@ -57,20 +61,36 @@ export class ConfigurationManager {
         return ConfigurationManager.getConfigValue('host') as string;
     }
 
-    static getPort(): string {
-        return ConfigurationManager.getConfigValue('port') as string;
+    static getPort(): number {
+        return Number(ConfigurationManager.getConfigValue('port'));
     }
 
     static getRestBasePath(): string {
         return ConfigurationManager.getConfigValue('restBasePath') as string;
     }
 
-    static getManagePort(): string {
-        return ConfigurationManager.getConfigValue('managePort') as string;
+    static getManagePort(): number {
+        return Number(ConfigurationManager.getConfigValue('managePort')) as number;
     }
 
     static getManageBasePath(): string {
         return ConfigurationManager.getConfigValue('manageBasePath') as string;
+    }
+
+    static getTestPort(): number {
+        return Number(ConfigurationManager.getConfigValue('testPort')) as number;
+    }
+
+    static getTestBasePath(): string {
+        return ConfigurationManager.getConfigValue('testBasePath') as string;
+    }
+
+    static getAdminPort(): number {
+        return Number(ConfigurationManager.getConfigValue('adminPort')) as number;
+    }
+
+    static getAdminBasePath(): string {
+        return ConfigurationManager.getConfigValue('testAdminPath') as string;
     }
 
     static getUsername(): string {
@@ -93,15 +113,15 @@ export class ConfigurationManager {
         return ConfigurationManager.getConfigValue('authType') as string;
     }
 
-    static getSsl(): string {
-        return ConfigurationManager.getConfigValue('ssl') as string;
+    static getSsl(): boolean {
+        return Boolean(ConfigurationManager.getConfigValue('ssl')) as boolean;
     }
 
     static getPathToCa(): string {
         return ConfigurationManager.getConfigValue('pathToCa') as string;
     }
 
-    static getRejectUnauthorized(): string {
-        return ConfigurationManager.getConfigValue('rejectUnauthorized') as string;
+    static getRejectUnauthorized(): boolean {
+        return Boolean(ConfigurationManager.getConfigValue('rejectUnauthorized')) as boolean;
     }
 }

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -94,12 +94,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const sendRowsXmlQuery = vscode.commands.registerTextEditorCommand(
         'extension.sendRowsXmlQuery', (editor: vscode.TextEditor) => sendEditorRowsQuery(editor, 'xml'));
     const runTestModule = vscode.commands.registerTextEditorCommand(
-        'extension.runTestModule',
-        (editor: vscode.TextEditor) => {
-            const cfg: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-            markLogicUnitTestClient.runTestModule(cfg, editor);
-        }
-    );
+        'extension.runTestModule', (editor: vscode.TextEditor) => markLogicUnitTestClient.runTestModule(editor));
     const validateTdeTemplate = vscode.commands.registerTextEditorCommand(
         'extension.validateTdeTemplate',
         (editor: vscode.TextEditor) => {

--- a/client/marklogicUnitTestClient.ts
+++ b/client/marklogicUnitTestClient.ts
@@ -17,12 +17,10 @@
 'use strict';
 
 import path = require('path');
-import {
-    ExtensionContext, TextEditor, WorkspaceConfiguration
-} from 'vscode';
+import { ExtensionContext, TextEditor, workspace } from 'vscode';
 
-import { ClientContext, MlClientParameters, newClientParams, requestMarkLogicUnitTest }
-    from './marklogicClient';
+import { ClientContext, requestMarkLogicUnitTest } from './marklogicClient';
+import { buildClientFactoryFromWorkspaceConfig } from './clientFactory';
 import { buildMlxprsErrorFromError, MlxprsError } from './mlxprsErrorBuilder';
 import { MlxprsErrorReporter } from './mlxprsErrorReporter';
 import { MlxprsWebViewProvider } from './mlxprsWebViewProvider';
@@ -41,7 +39,7 @@ export class MarkLogicUnitTestClient {
     }
 
     public async runTestModule(
-        cfg: WorkspaceConfiguration, editor: TextEditor
+        editor: TextEditor
     ): Promise<void> {
         const splitString = `test${path.sep}suites${path.sep}`;
         const filePath = editor.document.uri.path;
@@ -52,12 +50,9 @@ export class MarkLogicUnitTestClient {
             const testSuite = testPath.substring(0, lastSlash);
             const testFile = testPath.substring(lastSlash + 1);
 
-            const clientParams: MlClientParameters = newClientParams(cfg);
-            clientParams.port = clientParams.testPort;
-            clientParams.restBasePath = clientParams.testBasePath;
-            clientParams.contentDb = null;
-            clientParams.modulesDb = null;
-            const dbClientContext: ClientContext = new ClientContext(clientParams);
+            const dbClientContext: ClientContext =
+                buildClientFactoryFromWorkspaceConfig(workspace.getConfiguration())
+                    .newMarklogicRestClient();
             requestMarkLogicUnitTest(dbClientContext, testSuite, testFile)
                 .result((testResults: string) => {
                     const testResultsHtml = MlxprsWebViewProvider.convertXmlResponseToHtml(testResults);

--- a/client/test/integration/marklogicUnitTest.test.ts
+++ b/client/test/integration/marklogicUnitTest.test.ts
@@ -30,7 +30,7 @@ suite('Testing MarkLogic-Unit-Test functionality', async () => {
     const integrationTestHelper: IntegrationTestHelper = globalThis.integrationTestHelper;
 
     test('When a test is requested that should pass completely', async () => {
-        const mlUnitTestClient: ClientContext = new ClientContext(integrationTestHelper.mlUnitTestClientParameters);
+        const mlUnitTestClient: ClientContext = integrationTestHelper.mlUnitTestClientParameters.newMarklogicTestClient();
         await requestMarkLogicUnitTest(mlUnitTestClient, 'SampleJavaScriptTestSuite', 'sample-jstest.sjs')
             .result((testResults: string) => {
                 const parser = new XMLParser(options);
@@ -44,7 +44,7 @@ suite('Testing MarkLogic-Unit-Test functionality', async () => {
     }).timeout(5000);
 
     test('When a test is requested that does not exist', async () => {
-        const mlUnitTestClient: ClientContext = new ClientContext(integrationTestHelper.mlUnitTestClientParameters);
+        const mlUnitTestClient: ClientContext = integrationTestHelper.mlUnitTestClientParameters.newMarklogicTestClient();
         await requestMarkLogicUnitTest(mlUnitTestClient, 'SampleJavaScriptTestSuite', 'doesNotExist.sjs')
             .result((testResults: string) => {
                 const parser = new XMLParser(options);
@@ -60,7 +60,7 @@ suite('Testing MarkLogic-Unit-Test functionality', async () => {
     }).timeout(5000);
 
     test('When a test is requested that should have a failing test', async () => {
-        const mlUnitTestClient: ClientContext = new ClientContext(integrationTestHelper.mlUnitTestClientParameters);
+        const mlUnitTestClient: ClientContext = integrationTestHelper.mlUnitTestClientParameters.newMarklogicTestClient();
         await requestMarkLogicUnitTest(mlUnitTestClient, 'SampleJavaScriptTestSuite', 'sample-failing-jstest.sjs')
             .result((testResults: string) => {
                 const parser = new XMLParser(options);

--- a/test-app/.vscode/settings.json
+++ b/test-app/.vscode/settings.json
@@ -17,7 +17,7 @@
     "marklogic.testBasePath": "",
     "marklogic.adminPort": 8001,
     "marklogic.adminBasePath": "",
-}   // Use these for the reverse proxy and basePath testing
+    // Use these for the reverse proxy and basePath testing
     // "marklogic.port": 8020,
     // "marklogic.restBasePath": "/mlxprs/rest",
     // "marklogic.managePort": 8020,


### PR DESCRIPTION
MlClientParameters does too much now tracking different ports and paths, resulting in convoluted code. This is a first step in fixing that class. Replacing MlClientParameters in one fell swoop is too big and would lead to a ridiculous PR.

MlConnectionConfigurator is intended to be one stop shopping for storing all ML connection configuration parameters. Then using those values to generate any type of ClientContext required.

Note - this is part PR, part design proposal.
If you like it, we'll go with it.
If you hate it, I'll scrap it.
If you think it's interesting but need's more design, we'll discuss it.