### PR TITLE
Small testing improvement

### DIFF
--- a/client/test/integration/Issue69.test.ts
+++ b/client/test/integration/Issue69.test.ts
@@ -28,6 +28,7 @@ suite('Issue 69', async () => {
     const integrationTestHelper: IntegrationTestHelper = globalThis.integrationTestHelper;
 
     test('set breakpoints on two files', async () => {
+        await integrationTestHelper.restartMarkLogicAndWaitUntilItIsAvailableAgain();
         const globalConfig = integrationTestHelper.config;
         await JsDebugManager.connectToNamedJsDebugServer(integrationTestHelper.attachServerName);
         globalThis.integrationTestHelper.attachedToServer = true;
@@ -70,5 +71,5 @@ suite('Issue 69', async () => {
         await jsDebugClient.setBreakpointsRequest({ source: { path: Path.join('/MarkLogic/test', 'lib1.sjs') }, breakpoints: [] });
         await jsDebugClient.setBreakpointsRequest({ source: { path: Path.join('/MarkLogic/test', 'lib2.sjs') }, breakpoints: [] });
         await jsDebugClient.continueRequest({ threadId: 1 });
-    }).timeout(10000);
+    }).timeout(15000);
 });

--- a/client/test/integration/markLogicIntegrationTestHelper.ts
+++ b/client/test/integration/markLogicIntegrationTestHelper.ts
@@ -132,13 +132,7 @@ export class IntegrationTestHelper {
 
     async beforeEverything(): Promise<void> {
         await this.loadTestData();
-        await this.restartMarkLogic();
-        await wait(500);
-        let markLogicIsRunning = false;
-        while (!markLogicIsRunning) {
-            await wait(500);
-            markLogicIsRunning = await this.isMarkLogicRunning();
-        }
+        await this.restartMarkLogicAndWaitUntilItIsAvailableAgain();
     }
 
     async afterEverything(): Promise<void> {
@@ -205,14 +199,7 @@ export class IntegrationTestHelper {
         // Some tests can leave the MarkLogic server in a state that causes future tests to fail.
         // The only reliable method for resolving this state is to restart the MarkLogic server.
         if (globalThis.integrationTestHelper.restartServer) {
-            await this.restartMarkLogic();
-            globalThis.integrationTestHelper.restartServer = false;
-            await wait(500);
-            let markLogicIsRunning = false;
-            while (!markLogicIsRunning) {
-                await wait(500);
-                markLogicIsRunning = await this.isMarkLogicRunning();
-            }
+            await this.restartMarkLogicAndWaitUntilItIsAvailableAgain();
         }
 
         return new Promise((resolve) => {
@@ -286,6 +273,17 @@ export class IntegrationTestHelper {
                 (err) => {
                     throw err;
                 });
+    }
+
+    async restartMarkLogicAndWaitUntilItIsAvailableAgain() {
+        await this.restartMarkLogic();
+        globalThis.integrationTestHelper.restartServer = false;
+        await wait(500);
+        let markLogicIsRunning = false;
+        while (!markLogicIsRunning) {
+            await wait(500);
+            markLogicIsRunning = await this.isMarkLogicRunning();
+        }
     }
 
     private async restartMarkLogic(): Promise<string> {

--- a/client/test/integration/marklogicClient.test.ts
+++ b/client/test/integration/marklogicClient.test.ts
@@ -39,6 +39,7 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
     const clientFactory = new ClientFactory({ ...dbClientContext.params, ...overrides });
 
     test('When there are no "connected" app-servers initially', async () => {
+        await integrationTestHelper.restartMarkLogicAndWaitUntilItIsAvailableAgain();
         const disconnectedAppServers = await getFilteredListOfJsAppServers(clientFactory, 'false');
         assert.ok(disconnectedAppServers.length,
             'this will return an unpredictable number, but in any case it should be greater than 0');
@@ -53,7 +54,7 @@ suite('Testing \'disconnect\' functionality with varying scenarios', async () =>
             'This will return 1 fewer app servers than the previous number of disconnected app servers');
         const updatedConnectedAppServers = await getFilteredListOfJsAppServers(clientFactory, 'true');
         assert.equal(updatedConnectedAppServers.length, 1, 'This will return the single app server that was connected to');
-    }).timeout(5000);
+    }).timeout(15000);
 
 });
 


### PR DESCRIPTION
Makes a MarkLogic restart more reliable and easier to call for tests that expect MarkLogic to be in a "clean" state.
