### PR TITLE
Fixes a high vulnerability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "fast-xml-parser": "4.4.1",
                 "marklogic": "3.3.1",
                 "merge-options": "3.0.4",
+                "path-to-regexp": "6.3.0",
                 "ts-loader": "9.5.1",
                 "vscode-languageclient": "7.0.0",
                 "xml2js": "0.6.2"
@@ -3545,10 +3546,10 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-            "dev": true
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+            "license": "MIT"
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -7609,10 +7610,9 @@
             }
         },
         "path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-            "dev": true
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
         },
         "path-type": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
                 "runtime": "node",
                 "configurationAttributes": {
                     "launch": {
-                        "required": [],
+                        "required": [ ],
                         "properties": {
                             "path": {
                                 "type": "string",
@@ -248,7 +248,7 @@
                         }
                     }
                 ],
-                "variables": {}
+                "variables": { }
             },
             {
                 "type": "xquery-ml",
@@ -649,6 +649,7 @@
         "fast-xml-parser": "4.4.1",
         "marklogic": "3.3.1",
         "merge-options": "3.0.4",
+        "path-to-regexp": "6.3.0",
         "ts-loader": "9.5.1",
         "vscode-languageclient": "7.0.0",
         "xml2js": "0.6.2"

--- a/test-app/docker-compose.yaml
+++ b/test-app/docker-compose.yaml
@@ -4,7 +4,7 @@ name: mlxprs
 services:
 
   marklogic:
-    image: "marklogicdb/marklogic-db:11.1.0-centos-1.1.0"
+    image: "progressofficial/marklogic-db:latest"
     platform: linux/amd64
     environment:
       - INSTALL_CONVERTERS=true


### PR DESCRIPTION
Also updates the docker base image in the test app.
All the automated tests are passing locally, and the manual smoke tests work as well.

I'm wondering if we should have a 3.9.1 release for all of these dependency updates.