### PR TITLE
Revert one of the upgrades.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
             },
             "devDependencies": {
                 "@types/esprima": "4.0.6",
-                "@types/estree": "1.0.6",
-                "@types/mocha": "10.0.9",
+                "@types/estree": "1.0.5",
+                "@types/mocha": "10.0.6",
                 "@types/node": "16.11.7",
                 "@types/sinon": "17.0.3",
-                "@types/vscode": "1.94.0",
+                "@types/vscode": "1.78.0",
                 "@types/webpack": "5.28.5",
                 "@types/xml2js": "0.4.14",
                 "@typescript-eslint/eslint-plugin": "7.1.1",
@@ -467,9 +467,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -484,9 +484,9 @@
             "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
         },
         "node_modules/@types/mocha": {
-            "version": "10.0.9",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
-            "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+            "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
             "dev": true,
             "license": "MIT"
         },
@@ -518,9 +518,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.94.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.94.0.tgz",
-            "integrity": "sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==",
+            "version": "1.78.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
+            "integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
             "dev": true,
             "license": "MIT"
         },
@@ -5355,9 +5355,9 @@
             }
         },
         "@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
         },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.6",
@@ -5371,9 +5371,9 @@
             "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
         },
         "@types/mocha": {
-            "version": "10.0.9",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
-            "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+            "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
             "dev": true
         },
         "@types/node": {
@@ -5403,9 +5403,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.94.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.94.0.tgz",
-            "integrity": "sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==",
+            "version": "1.78.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
+            "integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
             "dev": true
         },
         "@types/webpack": {

--- a/package.json
+++ b/package.json
@@ -609,6 +609,7 @@
     "dependenciesComments": {
         "webpackProblem": "Something with version 5.95.0 is breaking the integration tests (and other things?).",
         "webpackFix": "I believe this will require upgrading the @types/node and will not be trivial.",
+        "@types/vscode": "This needs to match the value at the top of this file in 'engines.vscode`",
         "possiblyUnused": {
             "comment": "I'm not sure about these four packages. Without them, there seem to be problems when you attempt to 'attach' or 'launch'.",
             "@types/estree": "1.0.5",
@@ -619,11 +620,11 @@
     },
     "devDependencies": {
         "@types/esprima": "4.0.6",
-        "@types/estree": "1.0.6",
-        "@types/mocha": "10.0.9",
+        "@types/estree": "1.0.5",
+        "@types/mocha": "10.0.6",
         "@types/node": "16.11.7",
         "@types/sinon": "17.0.3",
-        "@types/vscode": "1.94.0",
+        "@types/vscode": "1.78.0",
         "@types/webpack": "5.28.5",
         "@types/xml2js": "0.4.14",
         "@typescript-eslint/eslint-plugin": "7.1.1",


### PR DESCRIPTION
While trying to build VSIX, I discovered that I had forgotten that the version of the '@types/vscode' can't be greater than the engines.vscode that is defined at the top of the package.json file. Therefore reverted that dependency version.
